### PR TITLE
Revenant nerf + added electrocutionChance

### DIFF
--- a/Content.Goobstation.Server/ChronoLegionnaire/Components/StasisOnCollideComponent.cs
+++ b/Content.Goobstation.Server/ChronoLegionnaire/Components/StasisOnCollideComponent.cs
@@ -17,7 +17,7 @@ namespace Content.Goobstation.Server.ChronoLegionnaire.Components;
 public sealed partial class StasisOnCollideComponent : Component
 {
     [DataField("stasisTime")]
-    public TimeSpan StasisTime = TimeSpan.FromSeconds(60);
+    public TimeSpan StasisTime = TimeSpan.FromSeconds(90); //Revenant nerf
 
     [DataField("fixture")]
     public string FixtureID = "projectile";

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -384,7 +384,6 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
         bool ignoreInsulation = false)
     {
         // Reserve edit - electrocution chance
-        Logger.Debug($"Electrocution chance check: {_random.Prob(electrocutionChance)} (chance: {electrocutionChance})");
         if (electrocutionChance < 1f && !_random.Prob(electrocutionChance))
             return false;
         // Reserve edit end

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -310,6 +310,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
                     TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth)),
                     true,
                     electrified.SiemensCoefficient,
+                    electrocutionChance: electrified.ElectrocutionChance, // Reserve edit
                     ignoreInsulation: electrified.IgnoreInsulation // Goobstation
                 );
             }
@@ -344,6 +345,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
                     TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth) * timeScalar),
                     true,
                     electrified.SiemensCoefficient,
+                    electrocutionChance: electrified.ElectrocutionChance, // Reserve edit
                     electrified.IgnoreInsulation); // Goob edit
             }
             return lastRet;
@@ -371,9 +373,22 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
 
     /// <inheritdoc/>
     public override bool TryDoElectrocution(
-        EntityUid uid, EntityUid? sourceUid, int shockDamage, TimeSpan time, bool refresh, float siemensCoefficient = 1f,
-        StatusEffectsComponent? statusEffects = null, bool ignoreInsulation = false)
+        EntityUid uid,
+        EntityUid? sourceUid,
+        int shockDamage,
+        TimeSpan time,
+        bool refresh,
+        float siemensCoefficient = 1f,
+        float electrocutionChance = 1f,// Reserve edit
+        StatusEffectsComponent? statusEffects = null,
+        bool ignoreInsulation = false)
     {
+        // Reserve edit - electrocution chance
+        Logger.Debug($"Electrocution chance check: {_random.Prob(electrocutionChance)} (chance: {electrocutionChance})");
+        if (electrocutionChance < 1f && !_random.Prob(electrocutionChance))
+            return false;
+        // Reserve edit end
+
         if (!DoCommonElectrocutionAttempt(uid, sourceUid, ref siemensCoefficient, ignoreInsulation)
             || !DoCommonElectrocution(uid, sourceUid, shockDamage, time, refresh, siemensCoefficient, statusEffects))
             return false;
@@ -390,10 +405,14 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
         TimeSpan time,
         bool refresh,
         float siemensCoefficient = 1f,
+        float electrocutionChance = 1f, //Reserve edit
         bool ignoreInsulation = false, // Goobstation
         StatusEffectsComponent? statusEffects = null,
         TransformComponent? sourceTransform = null)
     {
+        if (electrocutionChance < 1f && !_random.Prob(electrocutionChance)) //Reserve edit
+            return false;
+
         if (!DoCommonElectrocutionAttempt(uid, sourceUid, ref siemensCoefficient, ignoreInsulation)) // Goob edit
             return false;
 

--- a/Content.Server/EntityEffects/Effects/Electrocute.cs
+++ b/Content.Server/EntityEffects/Effects/Electrocute.cs
@@ -20,6 +20,8 @@ public sealed partial class Electrocute : EntityEffect
     /// </remarks>
     [DataField] public bool Refresh = true;
 
+    [DataField] public float ElectrocutionChance = 1f; // Reserve edit - ElectrocutionChance
+
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("reagent-effect-guidebook-electrocute", ("chance", Probability), ("time", ElectrocuteTime));
 
@@ -30,7 +32,7 @@ public sealed partial class Electrocute : EntityEffect
         if (args is EntityEffectReagentArgs reagentArgs)
         {
             reagentArgs.EntityManager.System<ElectrocutionSystem>().TryDoElectrocution(reagentArgs.TargetEntity, null,
-                Math.Max((reagentArgs.Quantity * ElectrocuteDamageScale).Int(), 1), TimeSpan.FromSeconds(ElectrocuteTime), Refresh, ignoreInsulation: true);
+                Math.Max((reagentArgs.Quantity * ElectrocuteDamageScale).Int(), 1), TimeSpan.FromSeconds(ElectrocuteTime), Refresh, electrocutionChance: ElectrocutionChance, ignoreInsulation: true); //Reserve edit - electrocutionChance
 
             if (reagentArgs.Reagent != null)
                 reagentArgs.Source?.RemoveReagent(reagentArgs.Reagent.ID, reagentArgs.Quantity);

--- a/Content.Server/_Shitcode/Wizard/Systems/ThrownLightningSystem.cs
+++ b/Content.Server/_Shitcode/Wizard/Systems/ThrownLightningSystem.cs
@@ -72,7 +72,7 @@ public sealed class ThrownLightningSystem : EntitySystem
         if (!TryComp(args.Target, out StatusEffectsComponent? status))
             return;
 
-        _electrocution.TryDoElectrocution(args.Target, ent, 2, TimeSpan.Zero, true, 0.5f, status, true);
+        _electrocution.TryDoElectrocution(args.Target, ent, 2, TimeSpan.Zero, true, 0.5f, 1f, status, true); //Reserve electrocutionChance
         _stamina.TakeStaminaDamage(args.Target, ent.Comp.StaminaDamage);
         _sparks.DoSparks(Transform(ent).Coordinates);
     }

--- a/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
+++ b/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
@@ -163,4 +163,12 @@ public sealed partial class ElectrifiedComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
     public EntityUid? IgnoredEntity;
+
+    /// <summary>
+    /// Reserve
+    /// Chance of entity to apply shock to target
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float ElectrocutionChance = 1f;
+
 }

--- a/Content.Shared/Electrocution/SharedElectrocutionSystem.cs
+++ b/Content.Shared/Electrocution/SharedElectrocutionSystem.cs
@@ -79,12 +79,13 @@ namespace Content.Shared.Electrocution
         /// <param name="time">How long the entity will be stunned.</param>
         /// <param name="refresh">Should <paramref>time</paramref> be refreshed (instead of accumilated) if the entity is already electrocuted?</param>
         /// <param name="siemensCoefficient">How insulated the entity is from the shock. 0 means completely insulated, and 1 means no insulation.</param>
+        /// <param name="electrocutionChance">Chance of appliend shock.</param>
         /// <param name="statusEffects">Status effects to apply to the entity.</param>
         /// <param name="ignoreInsulation">Should the electrocution bypass the Insulated component?</param>
         /// <returns>Whether the entity <see cref="uid"/> was stunned by the shock.</returns>
         public virtual bool TryDoElectrocution(
             EntityUid uid, EntityUid? sourceUid, int shockDamage, TimeSpan time, bool refresh, float siemensCoefficient = 1f,
-            StatusEffectsComponent? statusEffects = null, bool ignoreInsulation = false)
+            float electrocutionChance = 1f, StatusEffectsComponent? statusEffects = null, bool ignoreInsulation = false) //Reserve electrocutionChance
         {
             // only done serverside
             return false;

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/actions/revenant.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/actions/revenant.ftl
@@ -1,8 +1,14 @@
 ent-ActionRevenantShop = Магазин
     .desc = Открывает магазин способностей.
 ent-ActionRevenantDefile = Осквернение
-    .desc = Цена 30 эссенций.
+    .desc = Цена 30 эссенции.
 ent-ActionRevenantOverloadLights = Перегрузка ламп
-    .desc = Цена 40 эссенций.
+    .desc = Цена 40 эссенции.
 ent-ActionRevenantMalfunction = Сбой
-    .desc = Цена 60 эссенций.
+    .desc = Цена 60 эссенции.
+ent-ActionRevenantHaunt = Явление
+    .desc = Даёт эссенцию и дополнительно увеличивает количество эссенции за каждого, кто вас увидел.
+ent-ActionRevenantBloodWriting = Кровавые письмена
+    .desc = Стоит по 2 эссенции за рисунок.
+ent-ActionRevenantAnimate = Анимировать
+    .desc = Цена 50 эссенции.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -209,10 +209,11 @@
       types:
         Cold: 1.5 #may be painful if spammed, but doesnt ignores protection.
   - type: Electrified #idk this seems lame but it works fine
-    shockTime: 8 #4 seconds of stun
+    shockTime: 4 #2 seconds of stun
     shockDamage: 1
     requirePower: false
     ignoreInsulation: true
+    electrocutionChance: 0.25
   - type: WeakToHoly # Goobstation Shitchap
     alwaysTakeHoly: true
     #reserve revenant buff end

--- a/Resources/Prototypes/_Goobstation/Actions/revenant.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/revenant.yml
@@ -9,7 +9,7 @@
       sprite: Mobs/Ghosts/revenant.rsi
       state: icon
     event: !type:RevenantHauntActionEvent
-    useDelay: 20
+    useDelay: 45 #Revenant nerf
 
 - type: entity
   id: ActionRevenantBloodWriting


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Нерф ревенанта по результатам игровых тестов. 

Добавлен параметр, с помощью которого можно задать шанс, с которым будет применён шок. См.: https://github.com/Reserve-Station/Reserve-Station/pull/8/commits/b39c5082ac77df998ea49283d6f908a884419f9c

Added variable, that can determine chance of applying shock to target. See: https://github.com/Reserve-Station/Reserve-Station/pull/8/commits/b39c5082ac77df998ea49283d6f908a884419f9c
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Очень токсичная абилка с шоком, использовали исключительно её, чтобы держать людей в станлоке, а не как опция самозащиты.
## Technical details
<!-- Summary of code changes for easier review. -->
Что теперь:
- Время стана от шока: 4 -> 2 сек
- Вероятность шока 100% -> 25%
- Время в стазисе 60 -> 90 сек
- Кулдаун на стоковую "Пугалку" (Явление) 20 -> 45 сек


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Svarshik
- tweak: Баланс способностей ревенанта - теперь время шока и его вероятность разительно ниже.

