### PR TITLE
[Port] Achat sends data via webhook 

### DIFF
--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -108,9 +108,8 @@ using Robust.Shared.Player;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Errors;
 using Robust.Shared.Utility;
-using Content.Shared.ADT.CCVar;
-using Content.Server.Discord;
-using Serilog;
+using Content.Server.Discord; //Reserve ADT port
+using Serilog; //Reserve ADT port
 
 
 namespace Content.Server.Administration.Managers
@@ -189,9 +188,9 @@ namespace Content.Server.Administration.Managers
             SendPermsChangedEvent(session);
             UpdateAdminStatus(session);
             // ADT-Tweak-start: Постит сообщение в чат при деадмине
-            if (!string.IsNullOrEmpty(_cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook)))
+            if (!string.IsNullOrEmpty(_cfg.GetCVar(CCVars.DiscordAdminchatWebhook)))
             {
-                var webhookUrl = _cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook);
+                var webhookUrl = _cfg.GetCVar(CCVars.DiscordAdminchatWebhook);
                 if (webhookUrl == null)
                     return;
                 if (await _discord.GetWebhook(webhookUrl) is not { } webhookData)
@@ -291,9 +290,9 @@ namespace Content.Server.Administration.Managers
             SendPermsChangedEvent(session);
             UpdateAdminStatus(session);
             // ADT-Tweak-start: Постит сообщение в чат при деадмине
-            if (!string.IsNullOrEmpty(_cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook)))
+            if (!string.IsNullOrEmpty(_cfg.GetCVar(CCVars.DiscordAdminchatWebhook)))
             {
-                var webhookUrl = _cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook);
+                var webhookUrl = _cfg.GetCVar(CCVars.DiscordAdminchatWebhook);
                 if (webhookUrl == null)
                     return;
                 if (await _discord.GetWebhook(webhookUrl) is not { } webhookData)
@@ -501,9 +500,9 @@ namespace Content.Server.Administration.Managers
         // ADT-Tweak-start: Кидает инфу в дис если админ вышел из игры
         private async void DisconnectedAdminMaybe(ICommonSession session)
         {
-            if (!string.IsNullOrEmpty(_cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook)))
+            if (!string.IsNullOrEmpty(_cfg.GetCVar(CCVars.DiscordAdminchatWebhook)))
             {
-                var webhookUrl = _cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook);
+                var webhookUrl = _cfg.GetCVar(CCVars.DiscordAdminchatWebhook);
                 var senderName = session.Name;
                 if (await _discord.GetWebhook(webhookUrl) is not { } webhookData)
                     return;
@@ -554,9 +553,9 @@ namespace Content.Server.Administration.Managers
                         _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-admin-login-message",
                             ("name", session.Name)));
                         // ADT-Tweak-start: Кидает инфу в дис если админ зашёл
-                        if (!string.IsNullOrEmpty(_cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook)))
+                        if (!string.IsNullOrEmpty(_cfg.GetCVar(CCVars.DiscordAdminchatWebhook)))
                         {
-                            var webhookUrl = _cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook);
+                            var webhookUrl = _cfg.GetCVar(CCVars.DiscordAdminchatWebhook);
                             var senderAdmin = GetAdminData(session);
                             if (senderAdmin == null)
                                 return;

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -199,7 +199,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 using Content.Server._RMC14.LinkAccount; // RMC - Patreon
-using Content.Shared.ADT.CCVar; //Reserve edit
 using Content.Server.Discord; //Reserve edit
 
 namespace Content.Server.Chat.Managers;
@@ -483,18 +482,21 @@ internal sealed partial class ChatManager : IChatManager
 
         _adminLogger.Add(LogType.Chat, $"Admin chat from {player:Player}: {message}");
         // ADT-Tweak-start: Постит в дис весь админчат, если есть данный вебхук
-        if (!string.IsNullOrEmpty(_cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook)))
+        if (!string.IsNullOrEmpty(_cfg.GetCVar(CCVars.DiscordAdminchatWebhook)))
         {
-            var webhookUrl = _cfg.GetCVar(ADTDiscordWebhookCCVars.DiscordAdminchatWebhook);
+            var webhookUrl = _cfg.GetCVar(CCVars.DiscordAdminchatWebhook);
 
             if (webhookUrl == null)
                 return;
 
             if (await _discord.GetWebhook(webhookUrl) is not { } webhookData)
                 return;
+
+            var senderAdmin = _adminManager.GetAdminData(player);
+
             var payload = new WebhookPayload
             {
-                Content = $"***AdminChat***: **{senderName}**: {message}"
+                Content = $"{player.Name}[{(senderAdmin?.Title ?? "Admin")}]:\n{message}" //Reserve edit
             };
             var identifier = webhookData.ToIdentifier();
             await _discord.CreateMessage(identifier, payload);

--- a/Content.Shared/CCVar/CCVars.Discord.cs
+++ b/Content.Shared/CCVar/CCVars.Discord.cs
@@ -85,4 +85,10 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> DiscordBansWebhook =
         CVarDef.Create("discord.bans_webhook", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL);
 
+    /// <summary>
+    ///     Reserve - ADT port
+    ///     URL of the Discord adminchat info to the channel.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordAdminchatWebhook =
+        CVarDef.Create("discord.adminchat_webhook", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL | CVar.ARCHIVE);
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Теперь сообщения с ачата отсылаются в ДС через вебхук.
Порт https://github.com/AdventureTimeSS14/space_station_ADT/pull/938
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
недостающая штука. с дс в игру слало, а назад - нет

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

no cl no fun