### PR TITLE
handcuff-component-cuff-self-observer-success

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -469,8 +469,8 @@ namespace Content.Shared.Cuffs
                 _audio.PlayPredicted(component.EndCuffSound, uid, user);
 
                 var popupText = (user == target)
-                    ? "handcuff-component-cuff-self-observer-success-message"
-                    : "handcuff-component-cuff-observer-success-message";
+                    ? Loc.GetString("handcuff-component-cuff-self-observer-success-message") // reserve edit - fix this shit
+                    : Loc.GetString("handcuff-component-cuff-observer-success-message"); // reserve edit - fix this shit
                 _popup.PopupEntity(Loc.GetString(popupText,
                         ("user", Identity.Name(user, EntityManager)), ("target", Identity.Name(target, EntityManager))),
                     target, Filter.Pvs(target, entityManager: EntityManager)


### PR DESCRIPTION
:wilted_flower: 
<img width="526" height="145" alt="image" src="https://github.com/user-attachments/assets/1e5ee586-26c9-445b-a59d-c126987e8f5b" />

someone forgot to put Loc.GetString before doing locale, probably fixed in upstream but who cares