### PR TITLE
Orchid's Garden - Expand Microwave

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -114,7 +114,7 @@
   description: It's magic.
   components:
   - type: Microwave
-    capacity: 10
+    capacity: 30  # Reserve edit: Orchid's Garden - Expand Microwave
     canMicrowaveIdsSafely: false # Goobstation
     explosionChance: .25 # Goobstation
   - type: Appearance


### PR DESCRIPTION
## About the PR

Просто расширяет слоты микроволновки чтобы в нее помещались новые рецепты с ломтиками.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: Сад Орхидеи - Раширенная Микроволновка: слоты расширены до 30 для работы с обновлёнными рецептами.
