### PR TITLE
Fix burgers, tacos and skewers

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
@@ -128,7 +128,7 @@ namespace Content.Server.Nutrition.EntitySystems
             base.Initialize();
 
             // activate BEFORE entity is deleted and trash is spawned
-            SubscribeLocalEvent<CreamPieComponent, ConsumeDoAfterEvent>(OnConsume, before: [typeof(FoodSystem)]);
+            SubscribeLocalEvent<CreamPieComponent, ConsumeDoAfterEvent>(OnConsume, before: [typeof(EdibleComponent)]);  // Reserve edit: Fix burgers, tacos and skewers
             SubscribeLocalEvent<CreamPieComponent, SliceFoodEvent>(OnSlice);
 
             SubscribeLocalEvent<CreamPiedComponent, RejuvenateEvent>(OnRejuvenate);
@@ -140,7 +140,7 @@ namespace Content.Server.Nutrition.EntitySystems
             var coordinates = Transform(uid).Coordinates;
             _audio.PlayPvs(_audio.ResolveSound(creamPie.Sound), coordinates, AudioParams.Default.WithVariation(0.125f));
 
-            if (TryComp(uid, out FoodComponent? foodComp))
+            if (TryComp(uid, out EdibleComponent? foodComp))  // Reserve edit: Fix burgers, tacos and skewers
             {
                 if (_solutions.TryGetSolution(uid, foodComp.Solution, out _, out var solution))
                 {

--- a/Content.Shared/Nutrition/Components/EdibleComponent.cs
+++ b/Content.Shared/Nutrition/Components/EdibleComponent.cs
@@ -1,4 +1,8 @@
-﻿using Content.Shared.Body.Components;
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Body.Components;
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Nutrition.Prototypes;

--- a/Content.Shared/Nutrition/Components/EdibleComponent.cs
+++ b/Content.Shared/Nutrition/Components/EdibleComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Nutrition.Components;
 /// This is used on an entity with a solution container to flag a specific solution as being able to have its
 /// reagents consumed directly.
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(IngestionSystem))]
+[RegisterComponent, NetworkedComponent, Access(typeof(IngestionSystem), typeof(FoodSequenceSystem))]  // Reserve edit: Fix burgers, tacos and skewers
 public sealed partial class EdibleComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
@@ -122,16 +122,16 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
 
     private void OnInteractUsing(Entity<FoodSequenceStartPointComponent> ent, ref InteractUsingEvent args)
     {
-         if (HasComp<EntityStorageComponent>(args.Used)
-             || HasComp<StorageComponent>(args.Used)
-             || HasComp<UnremoveableComponent>(args.Used)) // Goobstation - Prevent burgering unremovable items
-             return; // Prevent Backpacks/Pet Carriers
+        if (HasComp<EntityStorageComponent>(args.Used)
+            || HasComp<StorageComponent>(args.Used)
+            || HasComp<UnremoveableComponent>(args.Used)) // Goobstation - Prevent burgering unremovable items
+            return; // Prevent Backpacks/Pet Carriers
 
-         if (ent.Comp.AcceptAll) // Goobstation - anythingburgers
-             EnsureComp<FoodSequenceElementComponent>(args.Used);
+        if (ent.Comp.AcceptAll) // Goobstation - anythingburgers
+            EnsureComp<FoodSequenceElementComponent>(args.Used);
 
-         if (TryComp<FoodSequenceElementComponent>(args.Used, out var sequenceElement) && HasComp<ItemComponent>(args.Used) && !HasComp<FoodSequenceStartPointComponent>(args.Used)) // Goobstation - anythingburgers - no non items allowed! otherwise you can grab players and lockers and such and add them to burgers
-             args.Handled = TryAddFoodElement(ent, (args.Used, sequenceElement), args.User);
+        if (TryComp<FoodSequenceElementComponent>(args.Used, out var sequenceElement) && HasComp<ItemComponent>(args.Used) && !HasComp<FoodSequenceStartPointComponent>(args.Used)) // Goobstation - anythingburgers - no non items allowed! otherwise you can grab players and lockers and such and add them to burgers
+            args.Handled = TryAddFoodElement(ent, (args.Used, sequenceElement), args.User);
     }
 
     private void OnIngredientAdded(Entity<FoodMetamorphableByAddingComponent> ent, ref FoodSequenceIngredientAddedEvent args)
@@ -317,10 +317,10 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
 
     private void MergeFoodSolutions(EntityUid start, EntityUid element)
     {
-        if (!TryComp<FoodComponent>(start, out var startFood))
+        if (!TryComp<EdibleComponent>(start, out var startFood))  // Reserve edit: Fix burgers, tacos and skewers
             return;
 
-        if (!TryComp<FoodComponent>(element, out var elementFood))
+        if (!TryComp<EdibleComponent>(element, out var elementFood))  // Reserve edit: Fix burgers, tacos and skewers
             return;
 
         if (!_solutionContainer.TryGetSolution(start, startFood.Solution, out var startSolutionEntity, out var startSolution))
@@ -360,10 +360,10 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
 
     private void MergeTrash(EntityUid start, EntityUid element)
     {
-        if (!TryComp<FoodComponent>(start, out var startFood))
+        if (!TryComp<EdibleComponent>(start, out var startFood))  // Reserve edit: Fix burgers, tacos and skewers
             return;
 
-        if (!TryComp<FoodComponent>(element, out var elementFood))
+        if (!TryComp<EdibleComponent>(element, out var elementFood))  // Reserve edit: Fix burgers, tacos and skewers
             return;
 
         foreach (var trash in elementFood.Trash)
@@ -412,10 +412,11 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
         // todo goob refactor this or move GravityWellComponent to shared
         // This kinda works but the teleport afterwards is kinda ass so replace or kill
         // you cant do this anyway with most things due to limit on stacking
-        else if (increment >= 8) {
+        else if (increment >= 8)
+        {
             EnsureComp<SpawnGravityWellComponent>(start, out var gravityWell);
-            gravityWell.MaxRange = (float)Math.Sqrt(increment/4);
-            gravityWell.BaseRadialAcceleration = (float)Math.Sqrt(increment/4);
+            gravityWell.MaxRange = (float) Math.Sqrt(increment / 4);
+            gravityWell.BaseRadialAcceleration = (float) Math.Sqrt(increment / 4);
         }
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
@@ -137,8 +137,11 @@
     - Trash
     - Skewer
   - type: Food
+  - type: Edible  # Reserve edit: Fix burgers, tacos and skewers
     trash:
     - FoodKebabSkewer
+  - type: FlavorProfile  # Reserve edit: Fix burgers, tacos and skewers
+    flavors: []
   - type: SolutionContainerManager
     solutions:
       food:


### PR DESCRIPTION
## About the PR

Чинит заброшенную оффами/губами систему крафтовых бургеров, тако и шампуров.

Проблемы, которые были решены:

- у шампуров всегда был неописуемый вкус вне зависимости от ингредиентов;
- реагенты ингредиентов не суммировались, т.е. бургеры, тако и шампуры всегда оставались пустыми по реагентам.

## Technical details

Теперь вместо устаревшего `FoodComponent` используется `EdibleComponent`, а у шампура теперь есть `FlavorProfileComponent` для суммирования вкусов.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- fix: Крафтовые бургеры, тако и шампуры снова суммируют вкусы и реагенты всей надетой на них еды.
