### PR TITLE
Guidebook Level Up 2.0

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -96,6 +96,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using System.Linq;
+using System.Numerics; // Reserve edit: guide-book #323
 // Reserve edit: guide-book #320
 using Content.Client.Guidebook;
 using Content.Client.Guidebook.RichText;
@@ -148,7 +149,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
         HomeButton.OnPressed += _ =>
         {
             if (_currentGuideEntry != null)
-                ShowGuide(_currentGuideEntry);
+                ShowGuide(_currentGuideEntry, resetState: true);
         };
         // Reserve edit end: guide-book #320
     }
@@ -181,10 +182,11 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
     {
         if (item != null && item.Metadata is GuideEntry entry)
         {
-            // Reserve edit start: guide-book #320
+            // Reserve edit start: guide-book #320, #323
+            SaveCurrentPageState();
             _currentGuideEntry = entry;
             ShowGuide(entry);
-            // Reserve edit end: guide-book #320
+            // Reserve edit end: guide-book #320, #323
 
             var isRulesEntry = entry.RuleEntry;
             ReturnContainer.Visible = isRulesEntry;
@@ -205,12 +207,26 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
         // Reserve edit end: guide-book #320
     }
 
-    private void ShowGuide(GuideEntry entry)
+    // Reserve edit start: guide-book #320, #323
+    public void SaveCurrentPageState()
     {
-        Scroll.SetScrollValue(default);
+        if (_currentGuideEntry == null)
+            return;
+
+        GuidebookPageStateStorage.States[_currentGuideEntry.Id] = new GuidebookPageState(
+            Scroll.GetScrollValue(),
+            SearchBar.Text ?? string.Empty,
+            CollectExpandedCollapsibles(EntryContainer),
+            CollectRevealedEntryAnchors(EntryContainer, SearchBar.Text ?? string.Empty));
+    }
+
+    private void ShowGuide(GuideEntry entry, bool resetState = false)
+    {
+        var pageState = resetState
+            ? GuidebookPageStateStorage.Empty
+            : GuidebookPageStateStorage.States.GetValueOrDefault(entry.Id, GuidebookPageStateStorage.Empty);
         Placeholder.Visible = false;
         EntryContainer.Visible = true;
-        SearchBar.Text = "";
         EntryContainer.RemoveAllChildren();
         // using var file = _resourceManager.ContentFileReadText(entry.Text); // Reserve localized guidebook begin
         // Get localized path
@@ -236,9 +252,172 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
 
         LastEntry = entry.Id;
 
-        // Reserve edit: guide-book #320
+        // Reserve edit: guide-book #320, #323
         _crossReferences.BuildFromPage(EntryContainer);
+        ApplyPageState(pageState);
     }
+
+    // Reserve edit: guide-book #323
+    private void ApplyPageState(GuidebookPageState state)
+    {
+        SearchBar.SetText(state.Search, invokeEvent: false);
+
+        if (!string.IsNullOrEmpty(state.Search))
+            HandleFilter();
+
+        UserInterfaceManager.DeferAction(() =>
+        {
+            ApplyRevealedEntryAnchors(EntryContainer, state.RevealedEntryAnchors);
+            ApplyCollapsibleStates(EntryContainer, state.ExpandedCollapsibles);
+            Scroll.SetScrollValue(state.Scroll);
+        });
+    }
+
+    private static HashSet<string> CollectRevealedEntryAnchors(Control root, string search)
+    {
+        var revealed = new HashSet<string>();
+
+        if (string.IsNullOrWhiteSpace(search))
+            return revealed;
+
+        var query = search.Trim();
+        foreach (var anchor in EnumerateEntryAnchors(root))
+        {
+            if (anchor is not Control { Visible: true } control)
+                continue;
+
+            if (control is not ISearchableControl searchable)
+                continue;
+
+            if (searchable.CheckMatchesSearch(query))
+                continue;
+
+            if (anchor.AnchorPrototype is { } proto)
+                revealed.Add(proto.ID);
+        }
+
+        return revealed;
+    }
+
+    private static void ApplyRevealedEntryAnchors(Control root, HashSet<string> revealed)
+    {
+        if (revealed.Count == 0)
+            return;
+
+        foreach (var anchor in EnumerateEntryAnchors(root))
+        {
+            if (anchor.AnchorPrototype is not { } proto)
+                continue;
+
+            if (!revealed.Contains(proto.ID))
+                continue;
+
+            if (anchor is Control control)
+                control.Visible = true;
+        }
+    }
+
+    private static IEnumerable<IGuidebookEntryAnchor> EnumerateEntryAnchors(Control root)
+    {
+        foreach (var child in root.Children)
+        {
+            if (child is IGuidebookEntryAnchor anchor)
+                yield return anchor;
+
+            foreach (var nested in EnumerateEntryAnchors(child))
+                yield return nested;
+        }
+    }
+
+    private static HashSet<string> CollectExpandedCollapsibles(Control root)
+    {
+        var expanded = new HashSet<string>();
+
+        foreach (var collapsible in EnumerateCollapsibles(root))
+        {
+            if (!IsCollapsibleExpanded(collapsible))
+                continue;
+
+            if (GetCollapsibleKey(collapsible) is { } key)
+                expanded.Add(key);
+        }
+
+        return expanded;
+    }
+
+    private static void ApplyCollapsibleStates(Control root, HashSet<string> expanded)
+    {
+        foreach (var collapsible in EnumerateCollapsibles(root))
+        {
+            if (GetCollapsibleKey(collapsible) is not { } key)
+                continue;
+
+            collapsible.BodyVisible = expanded.Contains(key);
+        }
+    }
+
+    private static IEnumerable<Collapsible> EnumerateCollapsibles(Control root)
+    {
+        foreach (var child in root.Children)
+        {
+            if (child is Collapsible collapsible)
+                yield return collapsible;
+
+            foreach (var nested in EnumerateCollapsibles(child))
+                yield return nested;
+        }
+    }
+
+    private static bool IsCollapsibleExpanded(Collapsible collapsible)
+    {
+        if (collapsible.BodyVisible)
+            return true;
+
+        var heading = GetCollapsibleHeading(collapsible);
+        return heading is { Pressed: true };
+    }
+
+    private static CollapsibleHeading? GetCollapsibleHeading(Collapsible collapsible)
+    {
+        if (collapsible.Heading is CollapsibleHeading heading)
+            return heading;
+
+        foreach (var child in collapsible.Children)
+        {
+            if (child is CollapsibleHeading collapsibleHeading)
+                return collapsibleHeading;
+        }
+
+        return null;
+    }
+
+    private static string? GetCollapsibleKey(Collapsible collapsible)
+    {
+        var sectionId = GetCollapsibleSectionId(collapsible);
+        if (string.IsNullOrEmpty(sectionId))
+            return null;
+
+        if (collapsible.TryGetParentHandler<IGuidebookEntryAnchor>(out var anchor)
+            && anchor.AnchorPrototype is { } anchorPrototype)
+        {
+            return $"{anchorPrototype.ID}|{sectionId}";
+        }
+
+        return sectionId;
+    }
+
+    private static string? GetCollapsibleSectionId(Collapsible collapsible)
+    {
+        for (var control = collapsible.Parent; control is not null; control = control.Parent)
+        {
+            if (!string.IsNullOrEmpty(control.Name))
+                return control.Name;
+        }
+
+        var heading = GetCollapsibleHeading(collapsible);
+        return heading?.Title ?? heading?.Label.Text;
+    }
+    // Reserve edit end: guide-book #320
 
     public void UpdateGuides(
         Dictionary<ProtoId<GuideEntryPrototype>, GuideEntry> entries,
@@ -353,11 +532,12 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
     {
         if (Tree.SelectedItem != null && Tree.SelectedItem.Metadata is GuideEntry entry && entry.FilterEnabled)
         {
+            var query = SearchBar.Text?.Trim() ?? string.Empty; // Reserve edit: guide-book #323
             var foundElements = EntryContainer.GetSearchableControls();
 
             foreach (var element in foundElements)
             {
-                element.SetHiddenState(true, SearchBar.Text.Trim());
+                element.SetHiddenState(true, query);
             }
         }
     }

--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -126,6 +126,9 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
     private Dictionary<ProtoId<GuideEntryPrototype>, GuideEntry> _entries = new();
     private readonly GuidebookCrossReferenceIndex _crossReferences = new();
     private GuideEntry? _currentGuideEntry;
+    private List<ProtoId<GuideEntryPrototype>>? _treeRootEntries;
+    private ProtoId<GuideEntryPrototype>? _treeForceRoot;
+    private bool _suppressSelectionReload;
 // Reserve edit end: guide-book #320
 
     private readonly ISawmill _sawmill;
@@ -149,7 +152,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
         HomeButton.OnPressed += _ =>
         {
             if (_currentGuideEntry != null)
-                ShowGuide(_currentGuideEntry, resetState: true);
+                ShowGuide(_currentGuideEntry, resetState: true); // Reserve edit: guide-book #323
         };
         // Reserve edit end: guide-book #320
     }
@@ -183,13 +186,19 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
         if (item != null && item.Metadata is GuideEntry entry)
         {
             // Reserve edit start: guide-book #320, #323
+            if (_suppressSelectionReload
+                || (_currentGuideEntry?.Id == entry.Id && EntryContainer.ChildCount > 0))
+            {
+                ReturnContainer.Visible = entry.RuleEntry;
+                return;
+            }
+
             SaveCurrentPageState();
             _currentGuideEntry = entry;
             ShowGuide(entry);
             // Reserve edit end: guide-book #320, #323
 
-            var isRulesEntry = entry.RuleEntry;
-            ReturnContainer.Visible = isRulesEntry;
+            ReturnContainer.Visible = entry.RuleEntry; // Reserve edit: guide-book #323
         }
         else
             ClearSelectedGuide();
@@ -217,7 +226,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
             Scroll.GetScrollValue(),
             SearchBar.Text ?? string.Empty,
             CollectExpandedCollapsibles(EntryContainer),
-            CollectRevealedEntryAnchors(EntryContainer, SearchBar.Text ?? string.Empty));
+            CollectRevealedEntryAnchors(EntryContainer, SearchBar.Text ?? string.Empty)); // Reserve edit: guide-book #323
     }
 
     private void ShowGuide(GuideEntry entry, bool resetState = false)
@@ -425,9 +434,22 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
         ProtoId<GuideEntryPrototype>? forceRoot = null,
         ProtoId<GuideEntryPrototype>? selected = null)
     {
-        _entries = entries;
-        RepopulateTree(rootEntries, forceRoot);
-        ClearSelectedGuide();
+        // Reserve edit start: guide-book #323
+        var keepPage = CanKeepCurrentPage(entries, rootEntries, forceRoot, selected);
+
+        if (!keepPage)
+        {
+            _entries = entries;
+            RepopulateTree(rootEntries, forceRoot);
+            _treeRootEntries = rootEntries;
+            _treeForceRoot = forceRoot;
+            ClearSelectedGuide();
+        }
+        else
+        {
+            _entries = entries;
+        }
+        // Reserve edit end: guide-book #323
 
         Split.State = SplitContainer.SplitState.Auto;
         if (entries.Count == 1)
@@ -442,12 +464,88 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IG
             Split.ResizeMode = SplitContainer.SplitResizeMode.RespectChildrenMinSize;
         }
 
+        // Reserve edit start: guide-book #323
+        if (keepPage)
+        {
+            EnsurePageVisible();
+            SyncTreeSelection(selected);
+            return;
+        }
+        // Reserve edit end: guide-book #323
+
         if (selected != null)
         {
             var item = Tree.Items.FirstOrDefault(x => x.Metadata is GuideEntry entry && entry.Id == selected);
             Tree.SetSelectedIndex(item?.Index);
         }
     }
+
+    // Reserve edit start: guide-book #323
+    private bool CanKeepCurrentPage(
+        Dictionary<ProtoId<GuideEntryPrototype>, GuideEntry> entries,
+        List<ProtoId<GuideEntryPrototype>>? rootEntries,
+        ProtoId<GuideEntryPrototype>? forceRoot,
+        ProtoId<GuideEntryPrototype>? selected)
+    {
+        if (selected == null || _currentGuideEntry?.Id != selected)
+            return false;
+
+        if (EntryContainer.ChildCount == 0)
+            return false;
+
+        if (_entries.Count != entries.Count)
+            return false;
+
+        foreach (var key in entries.Keys)
+        {
+            if (!_entries.ContainsKey(key))
+                return false;
+        }
+
+        if (_treeForceRoot != forceRoot)
+            return false;
+
+        return TreeRootsMatch(_treeRootEntries, rootEntries);
+    }
+
+    private static bool TreeRootsMatch(
+        List<ProtoId<GuideEntryPrototype>>? a,
+        List<ProtoId<GuideEntryPrototype>>? b)
+    {
+        if (a == null && b == null)
+            return true;
+
+        if (a == null || b == null)
+            return false;
+
+        return a.SequenceEqual(b);
+    }
+
+    private void EnsurePageVisible()
+    {
+        Placeholder.Visible = false;
+        EntryContainer.Visible = true;
+
+        if (_currentGuideEntry != null)
+            SearchContainer.Visible = _currentGuideEntry.FilterEnabled;
+    }
+
+    private void SyncTreeSelection(ProtoId<GuideEntryPrototype>? selected)
+    {
+        if (selected == null || _currentGuideEntry?.Id != selected)
+            return;
+
+        ReturnContainer.Visible = _currentGuideEntry.RuleEntry;
+
+        if (Tree.SelectedItem?.Metadata is GuideEntry entry && entry.Id == selected)
+            return;
+
+        var item = Tree.Items.FirstOrDefault(x => x.Metadata is GuideEntry e && e.Id == selected);
+        _suppressSelectionReload = true;
+        Tree.SetSelectedIndex(item?.Index);
+        _suppressSelectionReload = false;
+    }
+    // Reserve edit end: guide-book #323
 
     private IEnumerable<GuideEntry> GetSortedEntries(List<ProtoId<GuideEntryPrototype>>? rootEntries)
     {

--- a/Content.Client/Guidebook/FoodGuideDataSystem.cs
+++ b/Content.Client/Guidebook/FoodGuideDataSystem.cs
@@ -115,6 +115,8 @@ public sealed class FoodGuideDataSystem : EntitySystem
                 if (source.SourceEntity is { } parent && !IsPlant(parent))
                     ids.Add(parent);
             }
+
+            AddSliceProducts(id, ids); // Reserve edit: guide-book #323
         }
 
         return ids
@@ -122,6 +124,26 @@ public sealed class FoodGuideDataSystem : EntitySystem
             .Select(id => _prototypes.Index<EntityPrototype>(id))
             .OrderBy(p => p.Name);
     }
+
+    // Reserve edit start: guide-book #323
+    private void AddSliceProducts(EntProtoId parent, HashSet<EntProtoId> ids)
+    {
+        foreach (var (entityId, sources) in _sources)
+        {
+            if (ids.Contains(entityId))
+                continue;
+
+            foreach (var source in sources)
+            {
+                if (source.Kind != FoodEntitySourceKind.SliceFrom || source.SourceEntity != parent)
+                    continue;
+
+                ids.Add(entityId);
+                break;
+            }
+        }
+    }
+    // Reserve edit end: guide-book #323
 
     private void Rebuild()
     {
@@ -154,8 +176,7 @@ public sealed class FoodGuideDataSystem : EntitySystem
         foreach (var (slice, parent) in pendingSlices)
         {
             AddSource(slice, new FoodEntitySource(FoodEntitySourceKind.SliceFrom, null, parent, null));
-            if (_plantEntities.Contains(parent))
-                _plantEntities.Add(slice);
+            // Reserve remove: guide-book #323
         }
 
         IndexConstructionRollingSources();

--- a/Content.Client/Guidebook/GuidebookPageStateStorage.cs
+++ b/Content.Client/Guidebook/GuidebookPageStateStorage.cs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Collections.Generic;
+using System.Numerics;
+using Content.Shared.Guidebook;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client.Guidebook;
+
+internal readonly record struct GuidebookPageState(
+    Vector2 Scroll,
+    string Search,
+    HashSet<string> ExpandedCollapsibles,
+    HashSet<string> RevealedEntryAnchors);
+
+internal static class GuidebookPageStateStorage
+{
+    internal static readonly Dictionary<ProtoId<GuideEntryPrototype>, GuidebookPageState> States = new();
+
+    internal static readonly GuidebookPageState Empty = new(default, string.Empty, [], []);
+}

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -129,6 +129,8 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         _guideWindow.OnClose -= OnWindowClosed;
         _guideWindow.OnOpen -= OnWindowOpen;
 
+        _guideWindow.SaveCurrentPageState(); // Reserve edit: guide-book #323
+
         // shutdown
         _guideWindow.Dispose();
         _guideWindow = null;
@@ -190,6 +192,7 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         if (_guideWindow != null)
         {
             _guideWindow.ReturnContainer.Visible = false;
+            _guideWindow.SaveCurrentPageState(); // Reserve edit: guide-book #323
             _lastEntry = _guideWindow.LastEntry;
         }
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Гайдбук теперь сохраняет текущее свое положение. Вписали в фильтр химикатов "Фалангимин", закрыли гайдбук и открыли заново - в фильтре уже стоит фалангимин, а скролл там где остановились.

Добавлены рецепты нарезки овощей и так далее.

## Technical details
<!-- Summary of code changes for easier review. -->
* Добавлен GuidebookPageStateStorage - статическое хранилище состояния страниц гайдбука (скролл, поиск, раскрытые Collapsible, якоря, принудительно показанные фильтром)
* GuidebookWindow.SaveCurrentPageState() сохраняет состояние текущей страницы при смене раздела, закрытии окна и выходе из состояния игры/лобби
* ShowGuide() восстанавливает состояние вместо сброса скролла и поиска
* Раскрытые по кросс-ссылке элементы, скрытые фильтром, сохраняются в RevealedEntryAnchors и восстанавливаются при открытии гайдбука.
* Ключи Collapsible строятся по {prototypeId}|{containerName} через IGuidebookEntryAnchor (чтобы раскрывать collapsible при переоткрытии)
* UpdateGuides() пропускает пересборку страницы при повторном открытии того же раздела с тем же набором данных (CanKeepCurrentPage)
* OnSelectionChanged не вызывает ShowGuide, если выбран уже загруженный раздел = меньше лагов при повторных открытиях гайдбука. Гайдбук рисовался с нуля хотя сам по себе он не уничтожается при закрытии.
* GuidebookUIController вызывает SaveCurrentPageState() в OnWindowClosed и HandleStateExited
* FoodGuideDataSystem - добавлен AddSliceProducts для показа ломтиков в списке ингредиентов

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://youtu.be/lkbzcRZ9SmQ

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Гайдбук теперь сохраняет состояние при переоткрытии