### PR TITLE
Flip & spin antispam

### DIFF
--- a/Content.Goobstation.Server/MisandryBox/CatEmoteSpamCountermeasureSystem.cs
+++ b/Content.Goobstation.Server/MisandryBox/CatEmoteSpamCountermeasureSystem.cs
@@ -7,6 +7,8 @@ using Content.Goobstation.Common.MisandryBox;
 using Content.Goobstation.Shared.MisandryBox.Smites;
 using Content.Server.Chat.Systems;
 using Content.Shared.Chat.Prototypes;
+using Content.Shared.Damage.Systems;  // Reserve edit: Flip & spin antispam
+using Content.Shared.Damage.Components;  // Reserve edit: Flip & spin antispam
 using Content.Shared.Speech;
 using Robust.Shared.Random;
 
@@ -17,6 +19,7 @@ public sealed class CatEmoteSpamCountermeasureSystem : EntitySystem
 {
     [Dependency] private readonly ThunderstrikeSystem _thunderstrike = default!;
     [Dependency] private readonly IRobustRandom _rand = default!;
+    [Dependency] private readonly SharedStaminaSystem _stamina = default!;  // Reserve edit: Flip & spin antispam
 
     private const float ClearInterval = 20.0f;
     private const float PitchModulo = 0.08f;
@@ -91,10 +94,15 @@ public sealed class CatEmoteSpamCountermeasureSystem : EntitySystem
 
     private void OnEmoteEvent(Entity<SpeechComponent> ent, ref EmoteEvent args)
     {
+        // Reserve edit start: Flip & spin antispam
+        if (args.Emote.ID is "Spin" or "Flip" or "Jump" && TryComp<StaminaComponent>(ent.Owner, out _))
+            _stamina.TakeStaminaDamage(ent.Owner, 15f, visual: false, immediate: true);
+        // Reserve edit end: Flip & spin antispam
+
         if (
             (
                 args.Emote.Category is EmoteCategory.Vocal or EmoteCategory.Farts ||
-                args.Emote.ID is "Spin" or "Flip"  // Reserve edit: Smite too much flex. Add more as needed.
+                args.Emote.ID is "Spin" or "Flip"  // Reserve edit: Flip & spin antispam. Smite too much flex. Add more as needed.
             ) &&
             args.Voluntary
         )

--- a/Content.Goobstation.Server/MisandryBox/CatEmoteSpamCountermeasureSystem.cs
+++ b/Content.Goobstation.Server/MisandryBox/CatEmoteSpamCountermeasureSystem.cs
@@ -91,7 +91,13 @@ public sealed class CatEmoteSpamCountermeasureSystem : EntitySystem
 
     private void OnEmoteEvent(Entity<SpeechComponent> ent, ref EmoteEvent args)
     {
-        if (args.Emote.Category is EmoteCategory.Vocal or EmoteCategory.Farts && args.Voluntary)
+        if (
+            (
+                args.Emote.Category is EmoteCategory.Vocal or EmoteCategory.Farts ||
+                args.Emote.ID is "Spin" or "Flip"  // Reserve edit: Smite too much flex. Add more as needed.
+            ) &&
+            args.Voluntary
+        )
             Add(ent.Owner);
     }
 
@@ -125,7 +131,7 @@ public sealed class CatEmoteSpamCountermeasureSystem : EntitySystem
         // This is ground control to major tom
         var steps = count - soft;
         // By default, this is 8% per step over. 10 over soft threshold is 80%.
-        var chance = steps*_postSoftThresholdProbability;
+        var chance = steps * _postSoftThresholdProbability;
 
         if (_rand.Prob(chance))
             Smite(uid, false);

--- a/Content.Shared/Emoting/EmoteSystem.cs
+++ b/Content.Shared/Emoting/EmoteSystem.cs
@@ -12,6 +12,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.Damage.Components;  // Reserve edit: Flip & spin antispam
+
 namespace Content.Shared.Emoting;
 
 public sealed class EmoteSystem : EntitySystem
@@ -40,5 +42,10 @@ public sealed class EmoteSystem : EntitySystem
     {
         if (!TryComp(args.Uid, out EmotingComponent? emote) || !emote.Enabled)
             args.Cancel();
+
+        // Reserve edit start: Flip & spin antispam - can't emote while stamina-stunned
+        if (TryComp(args.Uid, out StaminaComponent? stamina) && stamina.Critical)
+            args.Cancel();
+        // Reserve edit end: Flip & spin antispam
     }
 }


### PR DESCRIPTION
## About the PR

Теперь прыжки, сальто и вращения отнимают выносливость.

Находясь в стан-крите из-за отсутсвия выносливости, игроки не могут использовать имоуты. Вообще.

А еще игра теперь бьет игроков молнией за спам сальто и вращениями. Если они как-то смогут обойти стамина-крит.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- add: Теперь сальто, прыжки и вращения отнимают стамину, а чрезмерный спам сальто и вращениями будет караться.
