### PR TITLE
Mail Fix

### DIFF
--- a/Content.Server/Nyanotrasen/Mail/Components/MailComponent.cs
+++ b/Content.Server/Nyanotrasen/Mail/Components/MailComponent.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Mail.Components
         [DataField]
         public bool IsLocked = true;
 
-        // Reserve edit start: localization #324
+        // Reserve edit start: mail-fix #328
         /// <summary>
         /// Whether this parcel must be unlocked with the recipient's ID before opening.
         /// Set by the mail teleporter; manually spawned mail stays unlocked.
@@ -39,7 +39,7 @@ namespace Content.Server.Mail.Components
         /// </summary>
         [DataField]
         public float OpenDelay = 3f;
-        // Reserve edit end: localization #324
+        // Reserve edit end: mail-fix #328
 
         /// <summary>
         /// Is this parcel profitable to deliver for the station?

--- a/Content.Server/Nyanotrasen/Mail/Components/MailComponent.cs
+++ b/Content.Server/Nyanotrasen/Mail/Components/MailComponent.cs
@@ -26,6 +26,21 @@ namespace Content.Server.Mail.Components
         [DataField]
         public bool IsLocked = true;
 
+        // Reserve edit start: localization #324
+        /// <summary>
+        /// Whether this parcel must be unlocked with the recipient's ID before opening.
+        /// Set by the mail teleporter; manually spawned mail stays unlocked.
+        /// </summary>
+        [DataField]
+        public bool RequiresIdUnlock;
+
+        /// <summary>
+        /// How long it takes to force-open a parcel with a sharp item.
+        /// </summary>
+        [DataField]
+        public float OpenDelay = 3f;
+        // Reserve edit end: localization #324
+
         /// <summary>
         /// Is this parcel profitable to deliver for the station?
         /// </summary>

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -27,7 +27,7 @@ using Content.Server.Chat.Systems;
 using Content.Server.Damage.Components;
 using Content.Server._DV.Cargo.Components;
 using Content.Server._DV.Cargo.Systems;
-using Content.Server.Kitchen.Components; // Reserve edit: localization #324
+using Content.Server.Kitchen.Components; // Reserve edit: mail-fix #328
 using Content.Server.Mail.Components;
 using Content.Server.Destructible.Thresholds.Behaviors;
 using Content.Server.Destructible.Thresholds.Triggers;
@@ -44,7 +44,7 @@ using Content.Shared.Access.Systems;
 using Content.Shared.Access;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage;
-using Content.Shared.DoAfter; // Reserve edit: localization #324
+using Content.Shared.DoAfter; // Reserve edit: mail-fix #328
 using Content.Shared.Mail;
 using Content.Shared.Destructible;
 using Content.Shared.Emag.Components;
@@ -135,7 +135,7 @@ namespace Content.Server.Mail
         [Dependency] private readonly MetaDataSystem _metaDataSystem = default!;
         [Dependency] private readonly EmagSystem _emag = default!;
         [Dependency] private readonly TurfSystem _turf = default!;
-        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // Reserve edit: localization #324
+        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // Reserve edit: mail-fix #328
 
         [Dependency] private readonly LogisticStatsSystem _logisticsStatsSystem = default!;
         [Dependency] private readonly RadioSystem _radioSystem = default!; // ImpStation - for radio notifications of new mail
@@ -152,15 +152,15 @@ namespace Content.Server.Mail
 
             SubscribeLocalEvent<MailComponent, ComponentRemove>(OnRemove);
             SubscribeLocalEvent<MailComponent, UseInHandEvent>(OnUseInHand);
-            SubscribeLocalEvent<MailComponent, InteractUsingEvent>(OnInteractUsing); // Reserve edit: localization #324
+            SubscribeLocalEvent<MailComponent, InteractUsingEvent>(OnInteractUsing); // Reserve edit: mail-fix #328
             SubscribeLocalEvent<MailComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
             SubscribeLocalEvent<MailComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<MailComponent, DestructionEventArgs>(OnDestruction);
             SubscribeLocalEvent<MailComponent, DamageChangedEvent>(OnDamage);
             SubscribeLocalEvent<MailComponent, BreakageEventArgs>(OnBreak);
             SubscribeLocalEvent<MailComponent, GotEmaggedEvent>(OnMailEmagged);
-            SubscribeLocalEvent<MailComponent, ComponentInit>(OnComponentInit); // Reserve edit: localization #324
-            SubscribeLocalEvent<MailComponent, MailForceOpenDoAfterEvent>(OnForceOpenDoAfter); // Reserve edit: localization #324
+            SubscribeLocalEvent<MailComponent, ComponentInit>(OnComponentInit); // Reserve edit: mail-fix #328
+            SubscribeLocalEvent<MailComponent, MailForceOpenDoAfterEvent>(OnForceOpenDoAfter); // Reserve edit: mail-fix #328
         }
 
         public override void Update(float frameTime)
@@ -246,7 +246,7 @@ namespace Content.Server.Mail
             component.IsPriority = false;
         }
 
-        // Reserve edit start: localization #324
+        // Reserve edit start: mail-fix #328
         /// <summary>
         /// Force-open mail with a sharp item. Handled on InteractUsing so utensil eating logic on the knife does not run first.
         /// </summary>
@@ -258,7 +258,7 @@ namespace Content.Server.Mail
             if (TryStartForceOpenDoAfter(uid, component, args.User, args.Used))
                 args.Handled = true;
         }
-        // Reserve edit end: localization #324
+        // Reserve edit end: mail-fix #328
 
         /// <summary>
         /// Check the ID against the mail's lock
@@ -463,7 +463,7 @@ namespace Content.Server.Mail
             args.Handled = true;
         }
 
-        // Reserve edit start: localization #324
+        // Reserve edit start: mail-fix #328
         private void OnComponentInit(EntityUid uid, MailComponent component, ComponentInit args)
         {
             if (!component.RequiresIdUnlock)
@@ -540,7 +540,7 @@ namespace Content.Server.Mail
             if (component.IsFragile)
                 _appearanceSystem.SetData(uid, MailVisuals.IsFragile, true);
         }
-        // Reserve edit end: localization #324
+        // Reserve edit end: mail-fix #328
 
         /// <summary>
         /// Returns true if the given entity is considered fragile for delivery.
@@ -634,13 +634,13 @@ namespace Content.Server.Mail
         {
             var mailComp = EnsureComp<MailComponent>(uid);
 
-            // Reserve edit start: localization #324
+            // Reserve edit start: mail-fix #328
             mailComp.RequiresIdUnlock = true;
             mailComp.IsLocked = true;
             UpdateAntiTamperVisuals(uid, true);
 
             PopulateMailContents(uid, mailComp, component.FragileDamageThreshold);
-            // Reserve edit end: localization #324
+            // Reserve edit end: mail-fix #328
 
             if (_random.Prob(component.PriorityChance))
                 mailComp.IsPriority = true;

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -159,7 +159,6 @@ namespace Content.Server.Mail
             SubscribeLocalEvent<MailComponent, DamageChangedEvent>(OnDamage);
             SubscribeLocalEvent<MailComponent, BreakageEventArgs>(OnBreak);
             SubscribeLocalEvent<MailComponent, GotEmaggedEvent>(OnMailEmagged);
-            SubscribeLocalEvent<MailComponent, MapInitEvent>(OnMapInit); // Reserve edit: mail-fix #328
             SubscribeLocalEvent<MailComponent, MailForceOpenDoAfterEvent>(OnForceOpenDoAfter); // Reserve edit: mail-fix #328
         }
 
@@ -464,7 +463,7 @@ namespace Content.Server.Mail
         }
 
         // Reserve edit start: mail-fix #328
-        private void OnMapInit(EntityUid uid, MailComponent component, MapInitEvent args)
+        public void InitializeMailOnMapInit(EntityUid uid, MailComponent component)
         {
             if (!component.RequiresIdUnlock)
             {

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -27,6 +27,7 @@ using Content.Server.Chat.Systems;
 using Content.Server.Damage.Components;
 using Content.Server._DV.Cargo.Components;
 using Content.Server._DV.Cargo.Systems;
+using Content.Server.Kitchen.Components; // Reserve edit: localization #324
 using Content.Server.Mail.Components;
 using Content.Server.Destructible.Thresholds.Behaviors;
 using Content.Server.Destructible.Thresholds.Triggers;
@@ -43,6 +44,7 @@ using Content.Shared.Access.Systems;
 using Content.Shared.Access;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage;
+using Content.Shared.DoAfter; // Reserve edit: localization #324
 using Content.Shared.Mail;
 using Content.Shared.Destructible;
 using Content.Shared.Emag.Components;
@@ -133,6 +135,7 @@ namespace Content.Server.Mail
         [Dependency] private readonly MetaDataSystem _metaDataSystem = default!;
         [Dependency] private readonly EmagSystem _emag = default!;
         [Dependency] private readonly TurfSystem _turf = default!;
+        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // Reserve edit: localization #324
 
         [Dependency] private readonly LogisticStatsSystem _logisticsStatsSystem = default!;
         [Dependency] private readonly RadioSystem _radioSystem = default!; // ImpStation - for radio notifications of new mail
@@ -149,12 +152,15 @@ namespace Content.Server.Mail
 
             SubscribeLocalEvent<MailComponent, ComponentRemove>(OnRemove);
             SubscribeLocalEvent<MailComponent, UseInHandEvent>(OnUseInHand);
+            SubscribeLocalEvent<MailComponent, InteractUsingEvent>(OnInteractUsing); // Reserve edit: localization #324
             SubscribeLocalEvent<MailComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
             SubscribeLocalEvent<MailComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<MailComponent, DestructionEventArgs>(OnDestruction);
             SubscribeLocalEvent<MailComponent, DamageChangedEvent>(OnDamage);
             SubscribeLocalEvent<MailComponent, BreakageEventArgs>(OnBreak);
             SubscribeLocalEvent<MailComponent, GotEmaggedEvent>(OnMailEmagged);
+            SubscribeLocalEvent<MailComponent, ComponentInit>(OnComponentInit); // Reserve edit: localization #324
+            SubscribeLocalEvent<MailComponent, MailForceOpenDoAfterEvent>(OnForceOpenDoAfter); // Reserve edit: localization #324
         }
 
         public override void Update(float frameTime)
@@ -239,6 +245,20 @@ namespace Content.Server.Mail
             // the priority tape description anymore.
             component.IsPriority = false;
         }
+
+        // Reserve edit start: localization #324
+        /// <summary>
+        /// Force-open mail with a sharp item. Handled on InteractUsing so utensil eating logic on the knife does not run first.
+        /// </summary>
+        private void OnInteractUsing(EntityUid uid, MailComponent component, InteractUsingEvent args)
+        {
+            if (args.Handled || !HasComp<SharpComponent>(args.Used))
+                return;
+
+            if (TryStartForceOpenDoAfter(uid, component, args.User, args.Used))
+                args.Handled = true;
+        }
+        // Reserve edit end: localization #324
 
         /// <summary>
         /// Check the ID against the mail's lock
@@ -443,6 +463,85 @@ namespace Content.Server.Mail
             args.Handled = true;
         }
 
+        // Reserve edit start: localization #324
+        private void OnComponentInit(EntityUid uid, MailComponent component, ComponentInit args)
+        {
+            if (!component.RequiresIdUnlock)
+            {
+                component.IsLocked = false;
+                UpdateAntiTamperVisuals(uid, false);
+            }
+
+            PopulateMailContents(uid, component);
+        }
+
+        private void OnForceOpenDoAfter(EntityUid uid, MailComponent component, MailForceOpenDoAfterEvent args)
+        {
+            if (args.Handled || args.Cancelled || !component.IsEnabled)
+                return;
+
+            if (component.IsLocked)
+            {
+                ExecuteForEachLogisticsStats(uid, (station, logisticStats) =>
+                {
+                    _logisticsStatsSystem.AddTamperedMailLosses(station,
+                        logisticStats,
+                        component.IsProfitable ? component.Penalty : 0);
+                });
+
+                PenalizeStationFailedDelivery(uid, component, "mail-penalty-lock");
+                UnlockMail(uid, component);
+            }
+
+            OpenMail(uid, component, args.User);
+            args.Handled = true;
+        }
+
+        private bool TryStartForceOpenDoAfter(EntityUid uid, MailComponent component, EntityUid user, EntityUid used)
+        {
+            if (!component.IsEnabled)
+                return false;
+
+            var doAfterArgs = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(component.OpenDelay),
+                new MailForceOpenDoAfterEvent(), uid, uid, used)
+            {
+                NeedHand = true,
+                BreakOnDamage = true,
+                BreakOnMove = true,
+            };
+
+            return _doAfterSystem.TryStartDoAfter(doAfterArgs);
+        }
+
+        private void PopulateMailContents(EntityUid uid, MailComponent component, int fragileDamageThreshold = 40)
+        {
+            if (component.Contents.Count == 0)
+                return;
+
+            var container = _containerSystem.EnsureContainer<Container>(uid, "contents");
+            if (container.ContainedEntities.Count > 0)
+                return;
+
+            foreach (var item in EntitySpawnCollection.GetSpawns(component.Contents, _random))
+            {
+                var entity = Spawn(item, Transform(uid).Coordinates);
+
+                if (!_containerSystem.Insert(entity, container))
+                {
+                    _sawmill.Error($"Can't insert {ToPrettyString(entity)} into mail {ToPrettyString(uid)}! Deleting it.");
+                    QueueDel(entity);
+                }
+                else if (!component.IsFragile && IsEntityFragile(entity, fragileDamageThreshold))
+                {
+                    component.IsFragile = true;
+                }
+            }
+
+            if (component.IsFragile)
+                _appearanceSystem.SetData(uid, MailVisuals.IsFragile, true);
+        }
+        // Reserve edit end: localization #324
+
         /// <summary>
         /// Returns true if the given entity is considered fragile for delivery.
         /// </summary>
@@ -535,21 +634,13 @@ namespace Content.Server.Mail
         {
             var mailComp = EnsureComp<MailComponent>(uid);
 
-            var container = _containerSystem.EnsureContainer<Container>(uid, "contents");
-            foreach (var item in EntitySpawnCollection.GetSpawns(mailComp.Contents, _random))
-            {
-                var entity = EntityManager.SpawnEntity(item, Transform(uid).Coordinates);
+            // Reserve edit start: localization #324
+            mailComp.RequiresIdUnlock = true;
+            mailComp.IsLocked = true;
+            UpdateAntiTamperVisuals(uid, true);
 
-                if (!_containerSystem.Insert(entity, container))
-                {
-                    _sawmill.Error($"Can't insert {ToPrettyString(entity)} into new mail delivery {ToPrettyString(uid)}! Deleting it.");
-                    QueueDel(entity);
-                }
-                else if (!mailComp.IsFragile && IsEntityFragile(entity, component.FragileDamageThreshold))
-                {
-                    mailComp.IsFragile = true;
-                }
-            }
+            PopulateMailContents(uid, mailComp, component.FragileDamageThreshold);
+            // Reserve edit end: localization #324
 
             if (_random.Prob(component.PriorityChance))
                 mailComp.IsPriority = true;

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -159,7 +159,7 @@ namespace Content.Server.Mail
             SubscribeLocalEvent<MailComponent, DamageChangedEvent>(OnDamage);
             SubscribeLocalEvent<MailComponent, BreakageEventArgs>(OnBreak);
             SubscribeLocalEvent<MailComponent, GotEmaggedEvent>(OnMailEmagged);
-            SubscribeLocalEvent<MailComponent, ComponentInit>(OnComponentInit); // Reserve edit: mail-fix #328
+            SubscribeLocalEvent<MailComponent, MapInitEvent>(OnMapInit); // Reserve edit: mail-fix #328
             SubscribeLocalEvent<MailComponent, MailForceOpenDoAfterEvent>(OnForceOpenDoAfter); // Reserve edit: mail-fix #328
         }
 
@@ -464,7 +464,7 @@ namespace Content.Server.Mail
         }
 
         // Reserve edit start: mail-fix #328
-        private void OnComponentInit(EntityUid uid, MailComponent component, ComponentInit args)
+        private void OnMapInit(EntityUid uid, MailComponent component, MapInitEvent args)
         {
             if (!component.RequiresIdUnlock)
             {

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
@@ -11,7 +11,7 @@ using Content.Server._DV.Cargo.Components;
 using Content.Server._DV.Cargo.Systems;
 using Content.Server.Station.Systems;
 using Content.Server.CartridgeLoader;
-using Content.Server.Mail;
+using Content.Server.Mail;  // Reserve edit: mail-fix #328
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Server.Mail.Components;
@@ -22,7 +22,7 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
 {
     [Dependency] private readonly CartridgeLoaderSystem _cartridgeLoader = default!;
     [Dependency] private readonly StationSystem _station = default!;
-    [Dependency] private readonly MailSystem _mail = default!;
+    [Dependency] private readonly MailSystem _mail = default!;  // Reserve edit: mail-fix #328
 
     public override void Initialize()
     {
@@ -45,7 +45,7 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, MailComponent mail, MapInitEvent args)
     {
-        _mail.InitializeMailOnMapInit(uid, mail);
+        _mail.InitializeMailOnMapInit(uid, mail);  // Reserve edit: mail-fix #328
 
         if (_station.GetOwningStation(uid) is { } station)
             UpdateAllCartridges(station);

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/MailMetricsCartridgeSystem.cs
@@ -11,6 +11,7 @@ using Content.Server._DV.Cargo.Components;
 using Content.Server._DV.Cargo.Systems;
 using Content.Server.Station.Systems;
 using Content.Server.CartridgeLoader;
+using Content.Server.Mail;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Server.Mail.Components;
@@ -21,6 +22,7 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
 {
     [Dependency] private readonly CartridgeLoaderSystem _cartridgeLoader = default!;
     [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly MailSystem _mail = default!;
 
     public override void Initialize()
     {
@@ -43,6 +45,8 @@ public sealed class MailMetricsCartridgeSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, MailComponent mail, MapInitEvent args)
     {
+        _mail.InitializeMailOnMapInit(uid, mail);
+
         if (_station.GetOwningStation(uid) is { } station)
             UpdateAllCartridges(station);
     }

--- a/Content.Server/_NF/Mail/DelayedItemSystem.cs
+++ b/Content.Server/_NF/Mail/DelayedItemSystem.cs
@@ -25,6 +25,7 @@ namespace Content.Server.Mail
             SubscribeLocalEvent<DelayedItemComponent, EntGotRemovedFromContainerMessage>(OnRemovedFromContainer);
         }
 
+        // Reserve edit start: mail-fix #328
         /// <summary>
         /// EntGotRemovedFromContainerMessage handler - spawn the intended entity after removed from a container.
         /// </summary>
@@ -35,6 +36,7 @@ namespace Content.Server.Mail
 
             Spawn(component.Item, Transform(uid).Coordinates);
         }
+        // Reserve edit end: mail-fix #328
 
         /// <summary>
         /// GotEquippedHandEvent handler - destroy the placeholder.
@@ -52,6 +54,7 @@ namespace Content.Server.Mail
             EntityManager.DeleteEntity(uid);
         }
 
+        // Reserve edit start: mail-fix #328
         /// <summary>
         /// OnDamageChanged handler - item has taken damage (e.g. inside the envelope), spawn the intended entity outside of any container and delete the placeholder.
         /// </summary>
@@ -63,5 +66,6 @@ namespace Content.Server.Mail
             Spawn(component.Item, Transform(uid).Coordinates);
             EntityManager.DeleteEntity(uid);
         }
+        // Reserve edit end: mail-fix #328
     }
 }

--- a/Content.Server/_NF/Mail/DelayedItemSystem.cs
+++ b/Content.Server/_NF/Mail/DelayedItemSystem.cs
@@ -28,8 +28,11 @@ namespace Content.Server.Mail
         /// <summary>
         /// EntGotRemovedFromContainerMessage handler - spawn the intended entity after removed from a container.
         /// </summary>
-        private void OnRemovedFromContainer(EntityUid uid, DelayedItemComponent component, ContainerModifiedMessage args)
+        private void OnRemovedFromContainer(EntityUid uid, DelayedItemComponent component, EntGotRemovedFromContainerMessage args)
         {
+            if (TerminatingOrDeleted(uid))
+                return;
+
             Spawn(component.Item, Transform(uid).Coordinates);
         }
 
@@ -54,6 +57,9 @@ namespace Content.Server.Mail
         /// </summary>
         private void OnDamageChanged(EntityUid uid, DelayedItemComponent component, DamageChangedEvent args)
         {
+            if (TerminatingOrDeleted(uid))
+                return;
+
             Spawn(component.Item, Transform(uid).Coordinates);
             EntityManager.DeleteEntity(uid);
         }

--- a/Content.Shared/Nyanotrasen/Mail/MailForceOpenDoAfterEvent.cs
+++ b/Content.Shared/Nyanotrasen/Mail/MailForceOpenDoAfterEvent.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Mail;
+
+[Serializable, NetSerializable]
+public sealed partial class MailForceOpenDoAfterEvent : SimpleDoAfterEvent;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Исправлен DoAfter вскрытия писем (теперь он происходит). Проблему вызвало возможность молей есть письма (DoAfter не успевал вызываться до попытки съесть).

Исправлен баг не позволяющий открывать письма без получателей. Теперь они спавнятся без получателя и исправно открываются. 

## Media
https://youtu.be/SRqDGFzZcsY


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Письма снова можно вскрывать острыми предметами.

