### PR TITLE
Slasher fix

### DIFF
--- a/Content.Goobstation.Server/Slasher/Systems/SlasherKitSelectSystem.cs
+++ b/Content.Goobstation.Server/Slasher/Systems/SlasherKitSelectSystem.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Content.Goobstation.Shared.Slasher.Components;
 using Content.Goobstation.Shared.Slasher.Systems;
 using Content.Goobstation.Shared.Slasher.UI;
+using Content.Server.Ghost.Roles.Components;
 using Content.Shared.Actions;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
@@ -91,6 +92,9 @@ public sealed class SlasherKitSelectSystem : EntitySystem
             return;
 
         var selectedKit = ent.Comp.Kits.Values.ElementAt(args.Index);
+
+        RemComp<GhostTakeoverAvailableComponent>(ent.Owner);
+        RemComp<GhostRoleComponent>(ent.Owner);
 
         EntityManager.AddComponents(ent.Owner, ent.Comp.PostSelectionComponents);
 

--- a/Content.Goobstation.Server/Slasher/Systems/SlasherKitSelectSystem.cs
+++ b/Content.Goobstation.Server/Slasher/Systems/SlasherKitSelectSystem.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Content.Goobstation.Shared.Slasher.Components;
 using Content.Goobstation.Shared.Slasher.Systems;
 using Content.Goobstation.Shared.Slasher.UI;
-using Content.Server.Ghost.Roles.Components;
 using Content.Shared.Actions;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
@@ -92,9 +91,6 @@ public sealed class SlasherKitSelectSystem : EntitySystem
             return;
 
         var selectedKit = ent.Comp.Kits.Values.ElementAt(args.Index);
-
-        RemComp<GhostTakeoverAvailableComponent>(ent.Owner);
-        RemComp<GhostRoleComponent>(ent.Owner);
 
         EntityManager.AddComponents(ent.Owner, ent.Comp.PostSelectionComponents);
 

--- a/Content.Goobstation.Server/Slasher/Systems/SlasherSystem.cs
+++ b/Content.Goobstation.Server/Slasher/Systems/SlasherSystem.cs
@@ -42,7 +42,7 @@ public sealed class SlasherSystem : EntitySystem
 
         var brain = brains[0];
 
-        if (brain.Comp2.SlotId != "brain")
+        if (brain.Comp2.SlotId != "brain")  // Reserve edit: Slasher fix
             return;
 
         EntityUid? chestPart = null;
@@ -55,12 +55,12 @@ public sealed class SlasherSystem : EntitySystem
         if (chestPart == null)
             return;
 
-        var slotId = brain.Comp2.SlotId;
+        var slotId = brain.Comp2.SlotId;  // Reserve edit: Slasher fix
 
         _body.RemoveOrgan(brain.Owner, brain.Comp2);
-        _body.TryCreateOrganSlot(chestPart, slotId, out _, null);
+        _body.TryCreateOrganSlot(chestPart, slotId, out _, null);  // Reserve edit: Slasher fix
 
-        if (!_body.InsertOrgan(chestPart.Value, brain.Owner, slotId))
+        if (!_body.InsertOrgan(chestPart.Value, brain.Owner, slotId))  // Reserve edit: Slasher fix
             return;
 
         _standing.Stand(ent.Owner, force: true);

--- a/Content.Goobstation.Server/Slasher/Systems/SlasherSystem.cs
+++ b/Content.Goobstation.Server/Slasher/Systems/SlasherSystem.cs
@@ -42,6 +42,9 @@ public sealed class SlasherSystem : EntitySystem
 
         var brain = brains[0];
 
+        if (brain.Comp2.SlotId != "brain")
+            return;
+
         EntityUid? chestPart = null;
         foreach (var (partId, part) in _body.GetBodyChildrenOfType(ent.Owner, BodyPartType.Chest, bodyComp))
         {
@@ -52,9 +55,14 @@ public sealed class SlasherSystem : EntitySystem
         if (chestPart == null)
             return;
 
+        var slotId = brain.Comp2.SlotId;
+
         _body.RemoveOrgan(brain.Owner, brain.Comp2);
-        _body.TryCreateOrganSlot(chestPart, "brain", out _, null);
-        _body.InsertOrgan(chestPart.Value, brain.Owner, "brain");
+        _body.TryCreateOrganSlot(chestPart, slotId, out _, null);
+
+        if (!_body.InsertOrgan(chestPart.Value, brain.Owner, slotId))
+            return;
+
         _standing.Stand(ent.Owner, force: true);
     }
 }

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -434,6 +434,7 @@
   - type: AntagLockerSpawn
   - type: AntagLoadProfileRule
     speciesOverride: Human
+    alwaysUseSpeciesOverride: true
     speciesOverrideBlacklist:
     - Yowie
     - IPC

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -434,7 +434,7 @@
   - type: AntagLockerSpawn
   - type: AntagLoadProfileRule
     speciesOverride: Human
-    alwaysUseSpeciesOverride: true
+    alwaysUseSpeciesOverride: true  # Reserve edit: Slasher fix
     speciesOverrideBlacklist:
     - Yowie
     - IPC


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Исправлен баг мясника: после выбора кита игрока выкидывало из тела при первом движении, а если взять гост роль - ломался сам мясник и не мог ходить.

## Technical details
<!-- Summary of code changes for easier review. -->
- SlasherSystem.cs:
-- MoveBrainToChest выполняется только для органа со слотом "brain".
-- Используется фактический SlotId органа вместо захардкоженного "brain". (Губам привет)
-- Добавлена проверка результата InsertOrgan, чтобы не оставлять тело в поломанном состоянии при неудачной вставке.
- midround.yml: alwaysUseSpeciesOverride: true - мясник всегда спавнится как человек (его предметы да и код рассчитаны на человека)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: слаймолюды и прочие не человеческие рассы больше не могут быть заспавнены мясником (будет спавнится человек).
