### PR TITLE
 Rnd console changes

### DIFF
--- a/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
+++ b/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
@@ -24,11 +24,11 @@ using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
-using Robust.Shared.Configuration; // Reserve edit: rnd-console #
+using Robust.Shared.Configuration; // Reserve edit: rnd-console #344
 using Robust.Shared.Input;
-using Robust.Shared; // Reserve edit: rnd-console #
+using Robust.Shared; // Reserve edit: rnd-console #344
 using Robust.Shared.Prototypes;
-using Robust.Shared.Timing; // Reserve edit: rnd-console #
+using Robust.Shared.Timing; // Reserve edit: rnd-console #344
 using Robust.Shared.Utility;
 
 namespace Content.Goobstation.Client.Research.UI;
@@ -42,8 +42,8 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     [Dependency] private readonly IEntityManager _entity = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
-    [Dependency] private readonly IGameTiming _timing = default!; // Reserve edit: rnd-console #
-    [Dependency] private readonly IConfigurationManager _cfg = default!; // Reserve edit: rnd-console #
+    [Dependency] private readonly IGameTiming _timing = default!; // Reserve edit: rnd-console #344
+    [Dependency] private readonly IConfigurationManager _cfg = default!; // Reserve edit: rnd-console #344
 
     private readonly ResearchSystem _research;
     private readonly SpriteSystem _sprite;
@@ -85,8 +85,8 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     private const float MaxZoom = 2f;
     private const float ZoomSpeed = 0.125f;
 
-    private string? _lastClickedTechId; // Reserve edit: rnd-console #
-    private TimeSpan _lastClickTime; // Reserve edit: rnd-console #
+    private string? _lastClickedTechId; // Reserve edit: rnd-console #344
+    private TimeSpan _lastClickTime; // Reserve edit: rnd-console #344
 
     public FancyResearchConsoleMenu()
     {
@@ -123,7 +123,7 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
             var control = new FancyResearchConsoleItem(proto, _sprite, tech.Value);
             DragContainer.AddChild(control);
 
-            ApplyItemLayout(control); // Reserve edit: rnd-console #
+            ApplyItemLayout(control); // Reserve edit: rnd-console #344
             control.SelectAction += SelectTech;
 
             if (tech.Key == CurrentTech)
@@ -196,11 +196,11 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     {
         base.MouseWheel(args);
 
-        // Reserve edit start: rnd-console #
+        // Reserve edit start: rnd-console #344
         var mousePos = args.GlobalPixelPosition.Position;
         if (!DragContainer.GlobalPixelRect.Contains((int) mousePos.X, (int) mousePos.Y))
             return;
-        // Reserve edit end: rnd-console #
+        // Reserve edit end: rnd-console #344
 
         var oldZoom = _zoom;
 
@@ -214,7 +214,7 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
         if (MathHelper.CloseTo(oldZoom, _zoom))
             return;
 
-        ApplyZoomToAllItems(); // Reserve edit: rnd-console #
+        ApplyZoomToAllItems(); // Reserve edit: rnd-console #344
         args.Handle();
     }
 
@@ -247,7 +247,7 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     /// <param name="availability">Tech availablity</param>
     public void SelectTech(TechnologyPrototype proto, ResearchAvailability availability)
     {
-        // Reserve edit start: rnd-console
+        // Reserve edit start: rnd-console #344
         var now = _timing.RealTime;
         var delay = TimeSpan.FromMilliseconds(_cfg.GetCVar(CVars.DoubleClickDelay));
         var isDoubleClick = _lastClickedTechId == proto.ID && now - _lastClickTime <= delay;
@@ -266,10 +266,10 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
 
         if (isDoubleClick)
             control.TryResearch();
-        // Reserve edit end: rnd-console
+        // Reserve edit end: rnd-console #344
     }
 
-    // Reserve edit start: rnd-console
+    // Reserve edit start: rnd-console #344
     private FancyTechnologyInfoPanel OpenInfoPanel(TechnologyPrototype proto, ResearchAvailability availability)
     {
         InfoContainer.RemoveAllChildren();
@@ -297,7 +297,7 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
                 ApplyItemLayout(research);
         }
     }
-    // Reserve edit end: rnd-console
+    // Reserve edit end: rnd-console #344
 
     /// <summary>
     /// Sets <see cref="_position"/> to its default value
@@ -305,14 +305,14 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     public void Recenter()
     {
         _position = new(45, 250);
-        ApplyZoomToAllItems(); // Reserve edit: rnd-console #
+        ApplyZoomToAllItems(); // Reserve edit: rnd-console #344
     }
 
     public override void Close()
     {
         base.Close();
 
-        _lastClickedTechId = null; // Reserve edit: rnd-console #
+        _lastClickedTechId = null; // Reserve edit: rnd-console #344
         DragContainer.RemoveAllChildren();
         InfoContainer.RemoveAllChildren();
     }

--- a/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
+++ b/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
@@ -24,8 +24,11 @@ using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
+using Robust.Shared.Configuration; // Reserve edit: rnd-console #
 using Robust.Shared.Input;
+using Robust.Shared; // Reserve edit: rnd-console #
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing; // Reserve edit: rnd-console #
 using Robust.Shared.Utility;
 
 namespace Content.Goobstation.Client.Research.UI;
@@ -39,6 +42,8 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     [Dependency] private readonly IEntityManager _entity = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IGameTiming _timing = default!; // Reserve edit: rnd-console #
+    [Dependency] private readonly IConfigurationManager _cfg = default!; // Reserve edit: rnd-console #
 
     private readonly ResearchSystem _research;
     private readonly SpriteSystem _sprite;
@@ -80,6 +85,9 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     private const float MaxZoom = 2f;
     private const float ZoomSpeed = 0.125f;
 
+    private string? _lastClickedTechId; // Reserve edit: rnd-console #
+    private TimeSpan _lastClickTime; // Reserve edit: rnd-console #
+
     public FancyResearchConsoleMenu()
     {
         RobustXamlLoader.Load(this);
@@ -115,9 +123,7 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
             var control = new FancyResearchConsoleItem(proto, _sprite, tech.Value);
             DragContainer.AddChild(control);
 
-            // Set position for all tech, relating to _position
-            LayoutContainer.SetPosition(control, _position + proto.Position * 150 * _zoom);
-            control.SetScale(_zoom); // Reserve edit: rnd-console #
+            ApplyItemLayout(control); // Reserve edit: rnd-console #
             control.SelectAction += SelectTech;
 
             if (tech.Key == CurrentTech)
@@ -208,15 +214,7 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
         if (MathHelper.CloseTo(oldZoom, _zoom))
             return;
 
-        foreach (var child in DragContainer.Children)
-        {
-            if (child is not FancyResearchConsoleItem research)
-                continue;
-
-            var pos = research.Prototype.Position * 150;
-            LayoutContainer.SetPosition(child, _position + pos * _zoom);
-            research.SetScale(_zoom);
-        }
+        ApplyZoomToAllItems(); // Reserve edit: rnd-console #
         args.Handle();
     }
 
@@ -249,15 +247,57 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     /// <param name="availability">Tech availablity</param>
     public void SelectTech(TechnologyPrototype proto, ResearchAvailability availability)
     {
-        InfoContainer.RemoveAllChildren();
+        // Reserve edit start: rnd-console
+        var now = _timing.RealTime;
+        var delay = TimeSpan.FromMilliseconds(_cfg.GetCVar(CVars.DoubleClickDelay));
+        var isDoubleClick = _lastClickedTechId == proto.ID && now - _lastClickTime <= delay;
+
+        _lastClickedTechId = proto.ID;
+        _lastClickTime = now;
+
         if (!_player.LocalEntity.HasValue)
+        {
+            InfoContainer.RemoveAllChildren();
             return;
+        }
 
         CurrentTech = proto.ID;
-        var control = new FancyTechnologyInfoPanel(proto, _accessReader.IsAllowed(_player.LocalEntity.Value, Entity), availability, _sprite);
+        var control = OpenInfoPanel(proto, availability);
+
+        if (isDoubleClick)
+            control.TryResearch();
+        // Reserve edit end: rnd-console
+    }
+
+    // Reserve edit start: rnd-console
+    private FancyTechnologyInfoPanel OpenInfoPanel(TechnologyPrototype proto, ResearchAvailability availability)
+    {
+        InfoContainer.RemoveAllChildren();
+
+        var control = new FancyTechnologyInfoPanel(proto, _accessReader.IsAllowed(_player.LocalEntity!.Value, Entity), availability, _sprite);
         control.BuyAction += args => OnTechnologyCardPressed?.Invoke(args.ID);
         InfoContainer.AddChild(control);
+        return control;
     }
+
+    private Vector2 GetItemPosition(TechnologyPrototype proto)
+        => _position + proto.Position * 150 * _zoom;
+
+    private void ApplyItemLayout(FancyResearchConsoleItem item)
+    {
+        LayoutContainer.SetPosition(item, GetItemPosition(item.Prototype));
+        item.SetScale(_zoom);
+    }
+
+    private void ApplyZoomToAllItems()
+    {
+        foreach (var child in DragContainer.Children)
+        {
+            if (child is FancyResearchConsoleItem research)
+                ApplyItemLayout(research);
+        }
+    }
+    // Reserve edit end: rnd-console
 
     /// <summary>
     /// Sets <see cref="_position"/> to its default value
@@ -265,20 +305,14 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     public void Recenter()
     {
         _position = new(45, 250);
-        foreach (var item in DragContainer.Children)
-        {
-            if (item is not FancyResearchConsoleItem research)
-                continue;
-
-            LayoutContainer.SetPosition(item, _position + research.Prototype.Position * 150 * _zoom);
-            research.SetScale(_zoom); // Reserve edit: rnd-console #
-        }
+        ApplyZoomToAllItems(); // Reserve edit: rnd-console #
     }
 
     public override void Close()
     {
         base.Close();
 
+        _lastClickedTechId = null; // Reserve edit: rnd-console #
         DragContainer.RemoveAllChildren();
         InfoContainer.RemoveAllChildren();
     }

--- a/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
+++ b/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
@@ -117,6 +117,7 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
 
             // Set position for all tech, relating to _position
             LayoutContainer.SetPosition(control, _position + proto.Position * 150 * _zoom);
+            control.SetScale(_zoom); // Reserve edit: rnd-console #
             control.SelectAction += SelectTech;
 
             if (tech.Key == CurrentTech)
@@ -188,6 +189,12 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
     protected override void MouseWheel(GUIMouseWheelEventArgs args)
     {
         base.MouseWheel(args);
+
+        // Reserve edit start: rnd-console #
+        var mousePos = args.GlobalPixelPosition.Position;
+        if (!DragContainer.GlobalPixelRect.Contains((int) mousePos.X, (int) mousePos.Y))
+            return;
+        // Reserve edit end: rnd-console #
 
         var oldZoom = _zoom;
 
@@ -264,6 +271,7 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
                 continue;
 
             LayoutContainer.SetPosition(item, _position + research.Prototype.Position * 150 * _zoom);
+            research.SetScale(_zoom); // Reserve edit: rnd-console #
         }
     }
 

--- a/Content.Goobstation.Client/Research/UI/FancyTechnologyInfoPanel.xaml.cs
+++ b/Content.Goobstation.Client/Research/UI/FancyTechnologyInfoPanel.xaml.cs
@@ -68,7 +68,7 @@ public sealed partial class FancyTechnologyInfoPanel : Control
         );
 
         ResearchButton.Disabled = !hasAccess || availability != ResearchAvailability.Available;
-        ResearchButton.OnPressed += OnResearchPressed; // Reserve edit: rnd-console #
+        ResearchButton.OnPressed += OnResearchPressed; // Reserve edit: rnd-console #344
     }
 
     private void InitializePrerequisites(TechnologyPrototype proto, ResearchSystem research, SpriteSystem sprite)
@@ -99,10 +99,10 @@ public sealed partial class FancyTechnologyInfoPanel : Control
     {
         base.ExitedTree();
 
-        ResearchButton.OnPressed -= OnResearchPressed; // Reserve edit: rnd-console #
+    ResearchButton.OnPressed -= OnResearchPressed; // Reserve edit: rnd-console #344
     }
 
-    // Reserve edit start: rnd-console
+    // Reserve edit start: rnd-console #344
     private void OnResearchPressed(BaseButton.ButtonEventArgs args)
         => TryResearch();
 
@@ -113,6 +113,6 @@ public sealed partial class FancyTechnologyInfoPanel : Control
 
         BuyAction?.Invoke(Prototype);
     }
-    // Reserve edit end: rnd-console
+    // Reserve edit end: rnd-console #344
 
 }

--- a/Content.Goobstation.Client/Research/UI/FancyTechnologyInfoPanel.xaml.cs
+++ b/Content.Goobstation.Client/Research/UI/FancyTechnologyInfoPanel.xaml.cs
@@ -68,7 +68,7 @@ public sealed partial class FancyTechnologyInfoPanel : Control
         );
 
         ResearchButton.Disabled = !hasAccess || availability != ResearchAvailability.Available;
-        ResearchButton.OnPressed += Bought;
+        ResearchButton.OnPressed += OnResearchPressed; // Reserve edit: rnd-console #
     }
 
     private void InitializePrerequisites(TechnologyPrototype proto, ResearchSystem research, SpriteSystem sprite)
@@ -99,11 +99,20 @@ public sealed partial class FancyTechnologyInfoPanel : Control
     {
         base.ExitedTree();
 
-        ResearchButton.OnPressed -= Bought;
+        ResearchButton.OnPressed -= OnResearchPressed; // Reserve edit: rnd-console #
     }
-    private void Bought(BaseButton.ButtonEventArgs args)
+
+    // Reserve edit start: rnd-console
+    private void OnResearchPressed(BaseButton.ButtonEventArgs args)
+        => TryResearch();
+
+    public void TryResearch()
     {
+        if (ResearchButton.Disabled)
+            return;
+
         BuyAction?.Invoke(Prototype);
     }
+    // Reserve edit end: rnd-console
 
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Исправляет баг, при котором любое изучение ломает Zoom консоли исследований. 
Добавляет шорткат для изучения - двойной клик по исследованию. 
Переносит одинаковую логику в хелперы (мини-функции). 

## Technical details
<!-- Summary of code changes for easier review. -->
1. Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
- Zoom работает только в дереве технологий (DragContainer), не над всем окном (исправляет скачки при исследованиях).
- Логика масштабов, инфопанели и зумов перенесена в отдельные хелперы для корректности кода (ApplyItemLayout, ApplyZoomToAllItems). 
- Двойной клик по технологии = быстрое изучение (время берется из CVars.DoubleClickDelay)
- Создание инфо-панели вынесено в OpenInfoPanel

2. Content.Goobstation.Client/Research/UI/FancyTechnologyInfoPanel.xaml.cs
- Добавлен TryResearch() - общая логика изучения (проверка ResearchButton.Disabled)
- Кнопка "Изучить" и двойной клик используют один путь через OnResearchPressed -> TryResearch()

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Добавлено быстрое действие (двойной клик) для исследования без нажатия на кнопку "Исследовать".
- fix: Консоль исследований более не сбрасывает зум при исследованиях.

