### PR TITLE
Ckey loadout items

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -255,7 +255,9 @@ namespace Content.Server.GameTicking
 
         public HumanoidCharacterProfile GetPlayerProfile(ICommonSession p)
         {
-            return (HumanoidCharacterProfile) _prefsManager.GetPreferences(p.UserId).SelectedCharacter;
+            // Reserve edit: use enriched spawn prefs so ckey-restricted loadout items auto-apply
+            // even for roles the player has never explicitly saved.
+            return (HumanoidCharacterProfile) _prefsManager.GetSpawnPreferences(p.UserId).SelectedCharacter;
         }
 
         public void PlayerJoinGame(ICommonSession session, bool silent = false)

--- a/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
@@ -39,6 +39,8 @@ namespace Content.Server.Preferences.Managers
         bool TryGetCachedPreferences(NetUserId userId, [NotNullWhen(true)] out PlayerPreferences? playerPreferences);
         PlayerPreferences GetPreferences(NetUserId userId);
         PlayerPreferences? GetPreferencesOrNull(NetUserId? userId);
+        // Reserve edit: enriched prefs used for spawning (includes all role loadouts for ckey-restricted items).
+        PlayerPreferences GetSpawnPreferences(NetUserId userId);
         IEnumerable<KeyValuePair<NetUserId, ICharacterProfile>> GetSelectedProfilesForPlayers(List<NetUserId> userIds);
         bool HavePreferencesLoaded(ICommonSession session);
 

--- a/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
@@ -40,6 +40,7 @@ using Content.Shared._White.CustomGhostSystem;
 using Content.Shared.CCVar;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Preferences;
+using Content.Shared.Preferences.Loadouts;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
@@ -150,6 +151,11 @@ namespace Content.Server.Preferences.Managers
 
             if (ShouldStorePrefs(session.Channel.AuthType))
                 await _db.SaveCharacterSlotAsync(userId, profile, slot);
+
+            // Reserve edit: repopulate missing role loadouts in the server cache after a save.
+            // Must be called after the DB save so the extra entries are not persisted to the database.
+            if (profile is HumanoidCharacterProfile savedHp)
+                EnsureMissingRoleLoadouts(savedHp, session);
         }
 
         private async void HandleDeleteCharacterMessage(MsgDeleteCharacter message)
@@ -344,11 +350,39 @@ namespace Content.Server.Preferences.Managers
             // Clean up preferences in case of changes to the game,
             // such as removed jobs still being selected.
             // WWDP EDIT START
-            return new PlayerPreferences(prefs.Characters.Select(p => new KeyValuePair<int, ICharacterProfile>(p.Key,
-                    p.Value.Validated(session, collection))), prefs.SelectedCharacterIndex, prefs.AdminOOCColor,
+            return new PlayerPreferences(prefs.Characters.Select(p =>
+            {
+                var validated = p.Value.Validated(session, collection);
+                // Reserve edit: populate missing role loadouts so ckey-restricted items
+                // (e.g. UniqueReserveItems) auto-apply correctly without needing a manual save.
+                if (validated is HumanoidCharacterProfile hp)
+                    EnsureMissingRoleLoadouts(hp, session);
+                return new KeyValuePair<int, ICharacterProfile>(p.Key, validated);
+            }), prefs.SelectedCharacterIndex, prefs.AdminOOCColor,
                     _protos.TryIndex<CustomGhostPrototype>(prefs.CustomGhost, out var ghostProto) && ghostProto.CanUse(session) ? prefs.CustomGhost : new ProtoId<CustomGhostPrototype>("default"),
                     prefs.ConstructionFavorites);
             // WWDP EDIT END
+        }
+
+        // Reserve edit: ensures that all RoleLoadoutPrototypes are represented in the server-side
+        // profile cache, even for roles the player has never explicitly saved. This allows
+        // session-dependent effects (e.g. CkeyRequirementLoadoutEffect) to be evaluated with a
+        // real session rather than the null session used in SpawnPlayerMob's SetDefault path.
+        // Only roles that actually produce items (minLimit > 0 groups with valid loadouts) are added
+        // to avoid inflating the profile unnecessarily.
+        private void EnsureMissingRoleLoadouts(HumanoidCharacterProfile profile, ICommonSession session)
+        {
+            foreach (var roleProto in _protos.EnumeratePrototypes<RoleLoadoutPrototype>())
+            {
+                if (profile.Loadouts.ContainsKey(roleProto.ID))
+                    continue;
+
+                var roleLoadout = new RoleLoadout(roleProto.ID);
+                roleLoadout.EnsureValid(profile, session, _dependencies);
+
+                if (roleLoadout.SelectedLoadouts.Values.Any(v => v.Count > 0))
+                    profile.SetLoadout(roleLoadout);
+            }
         }
 
         public IEnumerable<KeyValuePair<NetUserId, ICharacterProfile>> GetSelectedProfilesForPlayers(

--- a/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
@@ -148,14 +148,12 @@ namespace Content.Server.Preferences.Managers
             };
 
             prefsData.Prefs = curPrefs.WithCharacters(profiles).WithSlot(slot); // WWDP EDIT
+            // Reserve edit: update enriched spawn prefs; done before DB save so there is no window
+            // where SpawnPrefs lags behind Prefs.
+            prefsData.SpawnPrefs = CreateSpawnPrefs(session, prefsData.Prefs);
 
             if (ShouldStorePrefs(session.Channel.AuthType))
                 await _db.SaveCharacterSlotAsync(userId, profile, slot);
-
-            // Reserve edit: repopulate missing role loadouts in the server cache after a save.
-            // Must be called after the DB save so the extra entries are not persisted to the database.
-            if (profile is HumanoidCharacterProfile savedHp)
-                EnsureMissingRoleLoadouts(savedHp, session);
         }
 
         private async void HandleDeleteCharacterMessage(MsgDeleteCharacter message)
@@ -195,7 +193,7 @@ namespace Content.Server.Preferences.Managers
             var arr = new Dictionary<int, ICharacterProfile>(curPrefs.Characters);
             arr.Remove(slot);
 
-            prefsData.Prefs = curPrefs.WithCharacters(arr).WithSlot(nextSlot ?? curPrefs.SelectedCharacterIndex); // WWDP EDIT 
+            prefsData.Prefs = curPrefs.WithCharacters(arr).WithSlot(nextSlot ?? curPrefs.SelectedCharacterIndex); // WWDP EDIT
 
             if (!ShouldStorePrefs(message.MsgChannel.AuthType))
             {
@@ -252,6 +250,8 @@ namespace Content.Server.Preferences.Managers
             var prefsData = _cachedPlayerPrefs[session.UserId];
             DebugTools.Assert(prefsData.Prefs != null);
             prefsData.Prefs = SanitizePreferences(session, prefsData.Prefs, _dependencies);
+            // Reserve edit: separate enriched prefs used only for spawning, so canonical prefs stay unmodified.
+            prefsData.SpawnPrefs = CreateSpawnPrefs(session, prefsData.Prefs);
 
             prefsData.PrefsLoaded = true;
 
@@ -272,6 +272,7 @@ namespace Content.Server.Preferences.Managers
             var data = _cachedPlayerPrefs[session.UserId];
             DebugTools.Assert(data.Prefs != null);
             data.Prefs = SanitizePreferences(session, data.Prefs, _dependencies);
+            data.SpawnPrefs = CreateSpawnPrefs(session, data.Prefs);
             _sawmill.Debug("here");
         }
 
@@ -350,18 +351,38 @@ namespace Content.Server.Preferences.Managers
             // Clean up preferences in case of changes to the game,
             // such as removed jobs still being selected.
             // WWDP EDIT START
-            return new PlayerPreferences(prefs.Characters.Select(p =>
-            {
-                var validated = p.Value.Validated(session, collection);
-                // Reserve edit: populate missing role loadouts so ckey-restricted items
-                // (e.g. UniqueReserveItems) auto-apply correctly without needing a manual save.
-                if (validated is HumanoidCharacterProfile hp)
-                    EnsureMissingRoleLoadouts(hp, session);
-                return new KeyValuePair<int, ICharacterProfile>(p.Key, validated);
-            }), prefs.SelectedCharacterIndex, prefs.AdminOOCColor,
+            return new PlayerPreferences(prefs.Characters.Select(p => new KeyValuePair<int, ICharacterProfile>(p.Key,
+                    p.Value.Validated(session, collection))), prefs.SelectedCharacterIndex, prefs.AdminOOCColor,
                     _protos.TryIndex<CustomGhostPrototype>(prefs.CustomGhost, out var ghostProto) && ghostProto.CanUse(session) ? prefs.CustomGhost : new ProtoId<CustomGhostPrototype>("default"),
                     prefs.ConstructionFavorites);
             // WWDP EDIT END
+        }
+
+        // Reserve edit: returns an enriched copy of prefs where every RoleLoadoutPrototype is represented,
+        // even for roles the player has never explicitly saved.  This lets session-dependent loadout
+        // effects (e.g. CkeyRequirementLoadoutEffect) be evaluated with a real session rather than the
+        // null session that SpawnPlayerMob uses for profiles not yet in _loadouts.
+        // Only used for spawning; canonical prefs are never modified.
+        private PlayerPreferences CreateSpawnPrefs(ICommonSession session, PlayerPreferences prefs)
+        {
+            var enriched = prefs.Characters.Select(p =>
+            {
+                if (p.Value is not HumanoidCharacterProfile hp)
+                    return p;
+                var copy = hp.Clone();
+                EnsureMissingRoleLoadouts(copy, session);
+                return new KeyValuePair<int, ICharacterProfile>(p.Key, copy);
+            });
+            return new PlayerPreferences(enriched, prefs.SelectedCharacterIndex, prefs.AdminOOCColor,
+                prefs.CustomGhost, prefs.ConstructionFavorites);
+        }
+
+        // Reserve edit: returns prefs enriched with all role loadouts for spawning.
+        public PlayerPreferences GetSpawnPreferences(NetUserId userId)
+        {
+            if (_cachedPlayerPrefs.TryGetValue(userId, out var data) && data.SpawnPrefs != null)
+                return data.SpawnPrefs;
+            return GetPreferences(userId);
         }
 
         // Reserve edit: ensures that all RoleLoadoutPrototypes are represented in the server-side
@@ -403,6 +424,8 @@ namespace Content.Server.Preferences.Managers
         {
             public bool PrefsLoaded;
             public PlayerPreferences? Prefs;
+            // Reserve edit: enriched copy of Prefs with all role loadouts populated, used only for spawning.
+            public PlayerPreferences? SpawnPrefs;
         }
 
         void IPostInjectInit.PostInject()

--- a/Content.Shared/_Reserve/Preferences/Loadouts/Effects/CkeyRequirementLoadoutEffect.cs
+++ b/Content.Shared/_Reserve/Preferences/Loadouts/Effects/CkeyRequirementLoadoutEffect.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Ceterai <ceterai@protonmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Preferences.Loadouts.Effects;
+
+/// <summary>
+/// Checks for a Ckey match.
+/// </summary>
+public sealed partial class CkeyRequirementLoadoutEffect : LoadoutEffect
+{
+    [DataField(required: true)]
+    public List<string> Ckey = new();
+
+    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = FormattedMessage.FromUnformatted(Loc.GetString("loadout-group-unique-reserve-items-restriction"));
+
+        if (session == null)
+            return false;
+
+        var name = session.Name.ToLower();
+        if (name.StartsWith("localhost@"))
+            name = name[10..];
+
+        foreach (var testCkey in Ckey)
+            if (testCkey.ToLower() == name)
+            {
+                reason = null;
+                return true;
+            }
+
+        return false;
+    }
+}

--- a/Resources/Locale/en-US/_reserve/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_reserve/preferences/loadout-groups.ftl
@@ -1,0 +1,2 @@
+loadout-group-unique-reserve-items = Personal items
+loadout-group-unique-reserve-items-restriction = This is not your personal item.

--- a/Resources/Locale/ru-RU/_reserve/preferences/loadout-groups.ftl
+++ b/Resources/Locale/ru-RU/_reserve/preferences/loadout-groups.ftl
@@ -1,0 +1,2 @@
+loadout-group-unique-reserve-items = Персональные предметы
+loadout-group-unique-reserve-items-restriction = Это не ваш персональный предмет.

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -138,6 +138,7 @@
   - CaptainEnvirosuit
   - CaptainEnvirogloves
   - CaptainGloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobHeadOfPersonnel
@@ -158,6 +159,7 @@
   - HoPEnvirosuit
   - HoPEnvirogloves
   - HoPGloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 # Silicons
 - type: roleLoadout
   id: JobBorg
@@ -190,6 +192,7 @@
   - AssistantEnvirohelm
   - AssistantEnvirosuit
   - AssistantEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobBartender
@@ -208,6 +211,7 @@
   - BartenderEnvirohelm
   - BartenderEnvirosuit
   - BartenderEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobServiceWorker
@@ -224,6 +228,7 @@
   - ServiceWorkerEnvirohelm
   - ServiceWorkerEnvirosuit
   - ServiceWorkerEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobChef
@@ -244,6 +249,7 @@
   - ChefEnvirohelm
   - ChefEnvirosuit
   - ChefEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobLibrarian
@@ -260,6 +266,7 @@
   - LibrarianEnvirohelm
   - LibrarianEnvirosuit
   - LibrarianEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobLawyer
@@ -277,6 +284,7 @@
   - LawyerEnvirohelm
   - LawyerEnvirosuit
   - LawyerEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobChaplain
@@ -297,6 +305,7 @@
   - ChaplainEnvirohelm
   - ChaplainEnvirosuit
   - ChaplainEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobJanitor
@@ -317,6 +326,7 @@
   - JanitorEnvirohelm
   - JanitorEnvirosuit
   - JanitorEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobBotanist
@@ -337,6 +347,7 @@
   - BotanistEnvirohelm
   - BotanistEnvirosuit
   - BotanistEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobClown
@@ -356,6 +367,7 @@
   - ClownEnvirohelm
   - ClownEnvirosuit
   - ClownEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobMime
@@ -377,6 +389,7 @@
   - MimeEnvirosuit
   - MimeEnvirogloves
   - MimeGloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobMusician
@@ -395,6 +408,7 @@
   - MusicianEnvirohelm
   - MusicianEnvirosuit
   - MusicianEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 # Cargo
 - type: roleLoadout
@@ -416,6 +430,7 @@
   - QuartermasterEnvirohelm
   - QuartermasterEnvirosuit
   - QuartermasterEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobCargoTechnician
@@ -435,6 +450,7 @@
   - CargoTechnicianEnvirohelm
   - CargoTechnicianEnvirosuit
   - CargoTechnicianEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobSalvageSpecialist
@@ -454,6 +470,7 @@
   - SalvageEnvirohelm
   - SalvageEnvirosuit
   - SalvageEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 # Engineering
 - type: roleLoadout
@@ -474,6 +491,7 @@
   - ChiefEngineerEnvirohelm
   - ChiefEngineerEnvirosuit
   - ChiefEngineerEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobTechnicalAssistant
@@ -489,6 +507,7 @@
   - TechnicalAssistantEnvirohelm
   - TechnicalAssistantEnvirosuit
   - TechnicalAssistantEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobStationEngineer
@@ -508,6 +527,7 @@
   - StationEngineerEnvirohelm
   - StationEngineerEnvirosuit
   - StationEngineerEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobAtmosphericTechnician
@@ -526,6 +546,7 @@
   - AtmosEnvirohelm
   - AtmosEnvirosuit
   - AtmosEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 # Science
 - type: roleLoadout
@@ -548,6 +569,7 @@
   - ResearchDirectorEnvirosuit
   - ResearchDirectorEnvirohelm
   - ResearchDirectorEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobScientist
@@ -570,6 +592,7 @@
   - ScientistEnvirohelm
   - ScientistEnvirosuit
   - ScientistEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobResearchAssistant
@@ -586,6 +609,7 @@
   - ResearchAssistantEnvirohelm
   - ResearchAssistantEnvirosuit
   - ResearchAssistantEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 # Security
 - type: roleLoadout
@@ -609,6 +633,7 @@
   - HeadofSecurityEnvirosuit
   - HeadofSecurityEnvirogloves
   - HeadofSecurityGloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobWarden
@@ -630,6 +655,7 @@
   - WardenEnvirohelm
   - WardenEnvirosuit
   - WardenEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobSecurityOfficer
@@ -652,6 +678,7 @@
   - SecurityOfficerEnvirohelm
   - SecurityOfficerEnvirosuit
   - SecurityOfficerEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobDetective
@@ -672,6 +699,7 @@
   - DetectiveEnvirosuit
   - DetectiveEnvirogloves
   - DetectiveGloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobSecurityCadet
@@ -689,6 +717,7 @@
   - SecurityCadetEnvirohelm
   - SecurityCadetEnvirosuit
   - SecurityCadetEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 # Medical
 - type: roleLoadout
@@ -712,6 +741,7 @@
   - ChiefMedicalOfficerEnvirohelm
   - ChiefMedicalOfficerEnvirosuit
   - ChiefMedicalOfficerEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobMedicalDoctor
@@ -734,6 +764,7 @@
   - MedicalDoctorEnvirohelm
   - MedicalDoctorEnvirosuit
   - MedicalDoctorEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobMedicalIntern
@@ -750,6 +781,7 @@
   - MedicalInternEnvirohelm
   - MedicalInternEnvirosuit
   - MedicalInternEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobChemist
@@ -771,6 +803,7 @@
   - ChemistEnvirohelm
   - ChemistEnvirosuit
   - ChemistEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobParamedic
@@ -792,6 +825,7 @@
   - ParamedicEnvirohelm
   - ParamedicEnvirosuit
   - ParamedicEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 # Wildcards
 - type: roleLoadout
@@ -810,6 +844,7 @@
   - ZookeeperEnvirohelm
   - ZookeeperEnvirosuit
   - ZookeeperEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobReporter
@@ -827,6 +862,7 @@
   - ReporterEnvirohelm
   - ReporterEnvirosuit
   - ReporterEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobPsychologist
@@ -843,6 +879,7 @@
   - PsychologistEnvirohelm
   - PsychologistEnvirosuit
   - PsychologistEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobBoxer
@@ -859,6 +896,7 @@
   # Goobstation - EE Plasmeme Change.
   - BoxerEnvirohelm
   - BoxerEnvirosuit
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 # These loadouts are used for non-crew spawns, like off-station antags and event mobs
 # They will be used without player configuration, thus they will only ever apply what is forced by MinLimit

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -109,6 +109,7 @@
   - NanotrasenRepresentativeEnvirohelm
   - NanotrasenRepresentativeEnvirosuit
   - NanotrasenRepresentativeEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobBlueshieldOfficer
@@ -129,6 +130,7 @@
   - BlueshieldOfficerEnvirosuit
   - BlueshieldOfficerEnvirogloves
   - BlueshieldOfficerGloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobNanotrasenCareerTrainer
@@ -149,6 +151,7 @@
   - CentComOfficerEnvirohelm
   - CentComOfficerEnvirosuit
   - CentComOfficerEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: RoleSurvivalNukieHonkops
@@ -156,6 +159,7 @@
   - SurvivalSyndicate
   - GroupHonkopsMask
   - GroupPocketTankDouble
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobRoboticist
@@ -177,6 +181,7 @@
   - ScientistEnvirohelm
   - ScientistEnvirosuit
   - ScientistEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobBrigmedic
@@ -199,6 +204,7 @@
   - BrigmedicEnvirohelm
   - BrigmedicEnvirosuit
   - BrigmedicEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobRadioHost
@@ -214,6 +220,7 @@
   - ServiceWorkerEnvirohelm
   - ServiceWorkerEnvirosuit
   - ServiceWorkerEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 # gives plasmaman a plasma breathing tank
 # other species get nothing
@@ -230,6 +237,7 @@
   - ClownBackpack
   - SurvivalSecurity
   - GroupSpeciesBreathToolSecurity
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobCommandMaid
@@ -237,6 +245,7 @@
   - CommonBackpack
   - Survival
   - GroupSpeciesBreathTool
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobPartyMaker
@@ -245,6 +254,7 @@
   - CommonBackpack
   - Survival
   - GroupSpeciesBreathTool
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items
 
 - type: roleLoadout
   id: JobVirologist
@@ -264,3 +274,4 @@
    - VirologyEnvirohelm
    - VirologyEnvirosuit
    - VirologyEnvirogloves
+   - UniqueReserveItems  # Reserve edit: Ckey loadout items

--- a/Resources/Prototypes/_Lavaland/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Lavaland/Loadouts/role_loadouts.yml
@@ -16,3 +16,4 @@
   - SalvageEnvirohelm
   - SalvageEnvirosuit
   - SalvageEnvirogloves
+  - UniqueReserveItems  # Reserve edit: Ckey loadout items

--- a/Resources/Prototypes/_Lavaland/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Lavaland/Loadouts/role_loadouts.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: roleLoadout
   id: JobShaftMiner
   groups:

--- a/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/unique.yml
+++ b/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/unique.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 Ceterai <ceterai@protonmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# region Group
+
+- type: loadoutGroup
+  id: UniqueReserveItems
+  name: loadout-group-unique-reserve-items
+  minLimit: 1000  # So any new items are auto-applied.
+  maxLimit: 1000
+  hidden: true
+  loadouts:
+  - Orchito
+
+# endregion
+
+# region Items
+
+- type: loadout
+  id: Orchito
+  effects:
+  - !type:CkeyRequirementLoadoutEffect
+    ckey: [ Ceterai ]
+  storage:
+    back:
+    - DrinkOrchitoGlass
+
+# endregion


### PR DESCRIPTION
## About the PR

Добавляет требование к предметам лодаута, разрешенное лишь для определенных сикеев.

Имеется рабочий пример в виде стакана <img width="16" height="16" alt="Орхито" src="https://raw.githubusercontent.com/Ceterai/Reserve-Station/9df9a34800044d37b7691b9d3211150203ef57ef/Resources/Textures/_Reserve/Objects/Consumable/Drinks/orchito.rsi/icon.png" /> [орхито](https://github.com/Reserve-Station/Reserve-Station/pull/247), по умолчанию дающегося мне раундстартом.

## Technical details

Заранее создана лодаут группа и присвоена всем ролям. В нее можно добавлять любые новые уникальные предметы с проверкой по сикею.

Также можно создавать свои лодаут группы и даже делать их видимыми в настройках снаряжения - для предметов, не принадлежащих игроку, подготовлено сообщение "Это не ваш персональный предмет."

## Media

<img width="402" height="333" alt="image" src="https://github.com/user-attachments/assets/4d675e6c-edfa-49e6-8c7c-97341798fdfb" />

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- add: Добавлены лодаут-предметы, автоматически выдающиеся раундстартом по сикею. Это могут быть персональные плюши, карточки, и прочие "именные" безделушки. Пока что добавлен всего один такой предмет.
