### PR TITLE
Temporarily disable spell cards

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/spell_card.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/spell_card.yml
@@ -12,8 +12,8 @@
   - type: Sprite
     sprite: _Goobstation/Wizard/Projectiles/spellcard.rsi
     state: red
-  - type: SpecialAnimationOnUse
-    overrideText: "Особая Атака: 65 УДАР!!!!"  # Reserve edit: Fix special animation for cards
+  # - type: SpecialAnimationOnUse  # Reserve edit: Disabled until the range is fixed
+  #   overrideText: "Особая Атака: 65 УДАР!!!!"  # Reserve edit: Fix special animation for cards
   - type: UseDelay
     delay: 5
   - type: Card  # Reserve edit: Fix special animation for cards


### PR DESCRIPTION
## About the PR

Анимация карты заклинаний триггерится для всех, а не в радиусе. Это надо исправить, поэтому пока она отключена.

## Why / Balance

Спам.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
