### PR TITLE
Fix crawling

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
@@ -27,11 +27,13 @@ public abstract partial class SharedHandsSystem
         if (hands == 0)
             return;
 
-        time.DoAfterTime *= (float)ent.Comp.Count / (hands + ent.Comp.Count);
+        time.DoAfterTime *= (float) ent.Comp.Count / (hands + ent.Comp.Count);
     }
 
     private void OnKnockedDownRefresh(Entity<HandsComponent> ent, ref KnockedDownRefreshEvent args)
     {
+        // Reserve edit start: Fix crawling - You can crawl with your elbows, or even legs, though slowly.
+        /*
         var freeHands = CountFreeHands(ent.AsNullable());
         var totalHands = GetHandCount(ent.AsNullable());
 
@@ -41,5 +43,16 @@ public abstract partial class SharedHandsSystem
             args.SpeedModifier = 0f;
         else
             args.SpeedModifier *= (float)freeHands / totalHands;
+        */
+        var totalHands = GetHandCount(ent.AsNullable());
+        var totalSizePointsModifier = GetHeldItemSumSizePoints(ent.AsNullable()) * 0.01f;  // 1% for each point
+        var totalHandsModifier = 1.0f / (totalHands * 0.5f);  // 1 hand is 2x reduction, 2 hands is 1x, 4 hands 0.5x, etc.
+
+        // Entities without the HandsComponent will always have full crawling speed.
+        if (totalHands == 0)
+            args.SpeedModifier = 0.15f;
+        else
+            args.SpeedModifier *= Math.Max(1.0f - totalSizePointsModifier * totalHandsModifier, 0.05f);
+        // Reserve edit end: Fix crawling
     }
 }

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -15,6 +15,7 @@ using Robust.Shared.Input.Binding;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
+using Content.Shared.Item;
 
 namespace Content.Shared.Hands.EntitySystems;
 
@@ -451,6 +452,52 @@ public abstract partial class SharedHandsSystem
 
         return free;
     }
+
+    // Reserve edit start: Fix crawling
+    public ProtoId<ItemSizePrototype>? GetHeldItemSize(Entity<HandsComponent?> ent, string handId)
+    {
+        var item = GetHeldItem(ent, handId);
+        if (item is null)
+            return null;
+        if (!TryComp<ItemComponent>(item, out var sizeComp))
+            return null;
+        return sizeComp.Size;
+    }
+
+    public int GetHeldItemSizePoints(Entity<HandsComponent?> ent, string handId)
+    {
+        var size = GetHeldItemSize(ent, handId);
+        if (size is null)
+            return 0;
+        var sizeMap = new Dictionary<string, int>
+        {
+            { "Tiny", 1 },
+            { "Small", 2 },
+            { "Normal", 5 },
+            { "Large", 10 },
+            { "Huge", 17 },
+            { "Ginormous", 28 },
+        };
+        if (!sizeMap.ContainsKey(size))
+            return 0;
+        return sizeMap[size];
+    }
+
+    public int GetHeldItemSumSizePoints(Entity<HandsComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return 0;
+
+        var total = 0;
+        foreach (var name in ent.Comp.Hands.Keys)
+        {
+            if (!HandIsEmpty(ent, name))
+                total += GetHeldItemSizePoints(ent, name);
+        }
+
+        return total;
+    }
+    // Reserve edit end: Fix crawling
 
     /// <summary>
     /// Counts the number of hands that are empty or can be emptied by dropping an item.


### PR DESCRIPTION
# Описание PR

Чиним замедление при ползании с предметами в руках.

Как было до:

- Если в руках 0 предметов и у тебя 2 руки, ты ползешь с 100% скоростью.
- Если в руках 1 предмет и у тебя 2 руки, ты ползешь с 50% скоростью.
- Если в руках 2 предмета и у тебя 2 руки, ты лежишь на месте.
- Если у тебя были руки но все пропали, ты лежишь на месте.
- Если у тебя изначально нет рук (компонента), ты ползешь с 100% скоростью.

Как теперь:

- каждый размер предмета отнимает свое кол-во процентов от скорости:
  ```cs
        var sizeMap = new Dictionary<string, int>
        {
            { "Tiny", 1 }, // 1%
            { "Small", 2 },
            { "Normal", 5 },
            { "Large", 10 },
            { "Huge", 17 },
            { "Ginormous", 28 },
        };
  ```
- это зависит еще и от общего кол-ва рук - 4-рукому существу будет легче нести ту же ношу, чем 2-рукому:
  - если у вас всего 1 рука, проценты выше умножаются на два;
  - если у вас 2 руки, проценты выше не меняются;
  - если у вас 4 руки, проценты выше делятся на два;
  - и так далее.
- безрукие ребята (у которых должны быть руки, но отсутствуют), ползут с 15% скорости;
- ребята, которым руки и не нужны (нет компонента) будут всегда с полной скоростью.

## Изменения

:cl:
- tweak: Изменён подсчет скорости ползанья с предметами в руках - теперь она гораздо выше и зависит как от размеров предметов, что вы несёте, так и от общего количества ваших рук.
