### PR TITLE
Reserve Red bot link & profile integration

### DIFF
--- a/Content.Server/Content.Server.csproj
+++ b/Content.Server/Content.Server.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
     <PackageReference Include="NetCord" />
+    <PackageReference Include="NetCord.Services" /> <!-- Reserve edit: Full discord bot integration -->
     <PackageReference Include="prometheus-net" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
   </ItemGroup>

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -1787,6 +1787,60 @@ INSERT INTO player_round (players_id, rounds_id) VALUES ({players[player]}, {id}
 
         }
 
+        // Reserve edit start: Full discord bot integration
+        public async Task<ulong?> GetLinkedDiscordId(Guid player, CancellationToken cancel)
+        {
+            await using var db = await GetDb(cancel);
+            var linked = await db.DbContext.RMCLinkedAccounts.SingleOrDefaultAsync(l => l.PlayerId == player, cancel);
+            return linked?.DiscordId;
+        }
+        // Reserve edit end: Full discord bot integration
+
+        // Reserve edit start: Discord bot account linking
+        private static readonly TimeSpan LinkingCodeLifetime = TimeSpan.FromMinutes(10);
+
+        public async Task<NetUserId?> GetLinkedPlayerId(ulong discordId, CancellationToken cancel)
+        {
+            await using var db = await GetDb(cancel);
+            var linked = await db.DbContext.RMCLinkedAccounts.SingleOrDefaultAsync(l => l.DiscordId == discordId, cancel);
+            return linked == null ? null : new NetUserId(linked.PlayerId);
+        }
+
+        public async Task<(LinkAccountCodeResult Result, NetUserId? PlayerId)> ConsumeLinkingCode(Guid code, ulong discordId, CancellationToken cancel)
+        {
+            await using var db = await GetDb(cancel);
+
+            var linking = await db.DbContext.RMCLinkingCodes.SingleOrDefaultAsync(l => l.Code == code, cancel);
+            if (linking == null)
+                return (LinkAccountCodeResult.CodeNotFound, null);
+
+            if (DateTime.UtcNow - linking.CreationTime > LinkingCodeLifetime)
+                return (LinkAccountCodeResult.CodeExpired, null);
+
+            var existingForDiscord = await db.DbContext.RMCLinkedAccounts.SingleOrDefaultAsync(l => l.DiscordId == discordId, cancel);
+            if (existingForDiscord != null && existingForDiscord.PlayerId != linking.PlayerId)
+                return (LinkAccountCodeResult.DiscordAlreadyLinked, null);
+
+            var existingForPlayer = await db.DbContext.RMCLinkedAccounts.SingleOrDefaultAsync(l => l.PlayerId == linking.PlayerId, cancel);
+            if (existingForPlayer != null)
+            {
+                existingForPlayer.DiscordId = discordId;
+            }
+            else
+            {
+                if (!await db.DbContext.RMCDiscordAccounts.AnyAsync(d => d.Id == discordId, cancel))
+                    db.DbContext.RMCDiscordAccounts.Add(new RMCDiscordAccount { Id = discordId });
+
+                db.DbContext.RMCLinkedAccounts.Add(new RMCLinkedAccount { PlayerId = linking.PlayerId, DiscordId = discordId });
+            }
+
+            db.DbContext.RMCLinkingCodes.Remove(linking);
+            await db.DbContext.SaveChangesAsync(cancel);
+
+            return (LinkAccountCodeResult.Success, new NetUserId(linking.PlayerId));
+        }
+        // Reserve edit end: Discord bot account linking
+
         public async Task<RMCPatron?> GetPatron(Guid player, CancellationToken cancel)
         {
             await using var db = await GetDb(cancel);

--- a/Content.Server/Database/ServerDbManager.cs
+++ b/Content.Server/Database/ServerDbManager.cs
@@ -28,6 +28,16 @@ using MSLogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Content.Server.Database
 {
+    // Reserve edit start: Discord bot account linking
+    public enum LinkAccountCodeResult
+    {
+        Success,
+        CodeNotFound,
+        CodeExpired,
+        DiscordAlreadyLinked,
+    }
+    // Reserve edit end: Discord bot account linking
+
     public interface IServerDbManager
     {
         void Init();
@@ -315,6 +325,14 @@ namespace Content.Server.Database
         Task SetLinkingCode(Guid player, Guid code);
 
         Task<bool> HasLinkedAccount(Guid player, CancellationToken cancel);
+
+        Task<ulong?> GetLinkedDiscordId(Guid player, CancellationToken cancel);  // Reserve edit: Full discord bot integration
+
+        // Reserve edit start: Discord bot account linking
+        Task<NetUserId?> GetLinkedPlayerId(ulong discordId, CancellationToken cancel);
+
+        Task<(LinkAccountCodeResult Result, NetUserId? PlayerId)> ConsumeLinkingCode(Guid code, ulong discordId, CancellationToken cancel);
+        // Reserve edit end: Discord bot account linking
 
         Task<RMCPatron?> GetPatron(Guid player, CancellationToken cancel);
 
@@ -1083,6 +1101,28 @@ namespace Content.Server.Database
             DbReadOpsMetric.Inc();
             return RunDbCommand(() => _db.HasLinkedAccount(player, cancel));
         }
+
+        // Reserve edit start: Full discord bot integration
+        public Task<ulong?> GetLinkedDiscordId(Guid player, CancellationToken cancel)
+        {
+            DbReadOpsMetric.Inc();
+            return RunDbCommand(() => _db.GetLinkedDiscordId(player, cancel));
+        }
+        // Reserve edit end: Full discord bot integration
+
+        // Reserve edit start: Discord bot account linking
+        public Task<NetUserId?> GetLinkedPlayerId(ulong discordId, CancellationToken cancel)
+        {
+            DbReadOpsMetric.Inc();
+            return RunDbCommand(() => _db.GetLinkedPlayerId(discordId, cancel));
+        }
+
+        public Task<(LinkAccountCodeResult Result, NetUserId? PlayerId)> ConsumeLinkingCode(Guid code, ulong discordId, CancellationToken cancel)
+        {
+            DbWriteOpsMetric.Inc();
+            return RunDbCommand(() => _db.ConsumeLinkingCode(code, discordId, cancel));
+        }
+        // Reserve edit end: Discord bot account linking
 
         public Task<RMCPatron?> GetPatron(Guid player, CancellationToken cancel)
         {

--- a/Content.Server/Discord/DiscordLink/DiscordLink.cs
+++ b/Content.Server/Discord/DiscordLink/DiscordLink.cs
@@ -1,9 +1,13 @@
 ﻿using System.Collections.ObjectModel;
+using System.Linq;  // Reserve edit: Full discord bot integration
 using System.Threading.Tasks;
+using Content.Server._Reserve.Discord;  // Reserve edit: Full discord bot integration
 using Content.Shared.CCVar;
 using NetCord;
 using NetCord.Gateway;
 using NetCord.Rest;
+using DiscordInteraction = NetCord.Interaction;  // Reserve edit: Full discord bot integration
+using Robust.Shared.Asynchronous;  // Reserve edit: Full discord bot integration
 using Robust.Shared.Configuration;
 using Robust.Shared.Utility;
 
@@ -44,6 +48,7 @@ public sealed class DiscordLink : IPostInjectInit
 {
     [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IConfigurationManager _configuration = default!;
+    [Dependency] private readonly ITaskManager _taskManager = default!;  // Reserve edit: Full discord bot integration
 
     /// <summary>
     ///    The Discord client. This is null if the bot is not connected.
@@ -54,6 +59,8 @@ public sealed class DiscordLink : IPostInjectInit
     private GatewayClient? _client;
     private ISawmill _sawmill = default!;
     private ISawmill _sawmillLog = default!;
+    private DiscordProfileCog? _profileCog;  // Reserve edit: Full discord bot integration
+    private DiscordLinkCog? _linkCog;  // Reserve edit: Discord bot account linking
 
     private ulong _guildId;
     private string _botToken = string.Empty;
@@ -120,13 +127,18 @@ public sealed class DiscordLink : IPostInjectInit
         _client.MessageCreate += OnCommandReceivedInternal;
         _client.MessageCreate += OnMessageReceivedInternal;
 
+        _profileCog = new DiscordProfileCog();  // Reserve edit: Full discord bot integration
+        _linkCog = new DiscordLinkCog();  // Reserve edit: Discord bot account linking
+        _client.InteractionCreate += OnInteractionCreate;  // Reserve edit: Full discord bot integration
+
         _botToken = token;
         // Since you cannot change the token while the server is running / the DiscordLink is initialized,
         // we can just set the token without updating it every time the cvar changes.
 
-        _client.Ready += _ =>
+        _client.Ready += readyArgs =>  // Reserve edit: Full discord bot integration
         {
             _sawmill.Info("Discord client ready.");
+            _ = RegisterApplicationCommandsAsync();  // Reserve edit: Full discord bot integration
             return default;
         };
 
@@ -153,6 +165,7 @@ public sealed class DiscordLink : IPostInjectInit
             // Unsubscribe from the events.
             _client.MessageCreate -= OnCommandReceivedInternal;
             _client.MessageCreate -= OnMessageReceivedInternal;
+            _client.InteractionCreate -= OnInteractionCreate;  // Reserve edit: Full discord bot integration
 
             await _client.CloseAsync();
             _client.Dispose();
@@ -222,6 +235,141 @@ public sealed class DiscordLink : IPostInjectInit
         OnMessageReceived?.Invoke(message);
         return ValueTask.CompletedTask;
     }
+
+    // Reserve edit start: Full discord bot integration
+    private async ValueTask OnInteractionCreate(DiscordInteraction interaction)
+    {
+        if (interaction is not SlashCommandInteraction command)
+            return;
+
+        if (command.Data.Name == "link")
+        {
+            await HandleLinkCommand(command);
+            return;
+        }
+
+        if (_profileCog == null || command.Data.Name is not ("profile" or "balance" or "characters" or "inventory"))
+            return;
+
+        var player = command.Data.Options.FirstOrDefault(option => option.Name == "player")?.Value;
+        var privately = command.Data.Options.FirstOrDefault(option => option.Name == "privately")?.Value;
+        var ephemeral = privately is not null && bool.TryParse(privately, out var parsedPrivately)
+            ? parsedPrivately
+            : _configuration.GetCVar(CCVars.DiscordProfilePrivatelyDefault);
+
+        var response = await HandleProfileOnMainThread(command.Data.Name, player, command.User.Id, ephemeral);
+        await interaction.SendResponseAsync(response);
+    }
+
+    // Reserve edit start: Discord bot account linking
+    private async Task HandleLinkCommand(SlashCommandInteraction command)
+    {
+        if (_linkCog == null)
+            return;
+
+        var code = command.Data.Options.FirstOrDefault(option => option.Name == "code")?.Value ?? string.Empty;
+        var response = await HandleLinkOnMainThread(code, command.User.Id);
+        await command.SendResponseAsync(response);
+    }
+
+    private Task<InteractionCallback> HandleLinkOnMainThread(string code, ulong discordUserId)
+    {
+        var completion = new TaskCompletionSource<InteractionCallback>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _taskManager.RunOnMainThread(async () =>
+        {
+            try
+            {
+                completion.SetResult(await _linkCog!.HandleAsync(code, discordUserId));
+            }
+            catch (Exception e)
+            {
+                completion.SetException(e);
+            }
+        });
+
+        return completion.Task;
+    }
+    // Reserve edit end: Discord bot account linking
+
+    private Task<InteractionCallback> HandleProfileOnMainThread(string command, string? player, ulong discordUserId, bool ephemeral)
+    {
+        var completion = new TaskCompletionSource<InteractionCallback>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _taskManager.RunOnMainThread(async () =>
+        {
+            try
+            {
+                completion.SetResult(await _profileCog!.HandleAsync(command, player, discordUserId, ephemeral, _client!.Rest, _guildId));
+            }
+            catch (Exception e)
+            {
+                completion.SetException(e);
+            }
+        });
+
+        return completion.Task;
+    }
+
+    private async Task RegisterApplicationCommandsAsync()
+    {
+        if (_client == null)
+            return;
+
+        try
+        {
+            var commandDefinitions = new[]
+            {
+                CreateProfileCommand("profile", "Show a player's complete profile."),
+                CreateProfileCommand("balance", "Show a player's coin balance."),
+                CreateProfileCommand("characters", "Show a player's characters."),
+                CreateProfileCommand("inventory", "Show a player's bought tokens."),
+                CreateLinkCommand(),
+            };
+
+            var registeredCommands = await _client.Rest.GetGuildApplicationCommandsAsync(_client.Id, _guildId);
+            foreach (var command in commandDefinitions)
+            {
+                if (registeredCommands.Any(registered => registered.Name == command.Name))
+                    continue;
+
+                await _client.Rest.CreateGuildApplicationCommandAsync(_client.Id, _guildId, command);
+            }
+
+            _sawmill.Info("Registered Discord application commands.");
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error("Failed to register Discord application commands!", e);
+        }
+    }
+
+    private static SlashCommandProperties CreateProfileCommand(string name, string description)
+    {
+        return new SlashCommandProperties(name, description)
+            .AddOptions(
+                new ApplicationCommandOptionProperties(
+                    ApplicationCommandOptionType.String,
+                    "player",
+                    "Player CKey or UID (defaults to your own linked account)"),
+                new ApplicationCommandOptionProperties(
+                    ApplicationCommandOptionType.Boolean,
+                    "privately",
+                    "Only show the response to you (default: false)"));
+    }
+    // Reserve edit end: Full discord bot integration
+
+    // Reserve edit start: Discord bot account linking
+    private static SlashCommandProperties CreateLinkCommand()
+    {
+        return new SlashCommandProperties("link", "Link your Discord account to your in-game account.")
+            .AddOptions(new ApplicationCommandOptionProperties(
+                ApplicationCommandOptionType.String,
+                "code",
+                "The linking code shown in-game")
+                .WithRequired(true));
+    }
+    // Reserve edit end: Discord bot account linking
 
     #region Proxy methods
 

--- a/Content.Server/_Reserve/Discord/DiscordLinkCog.cs
+++ b/Content.Server/_Reserve/Discord/DiscordLinkCog.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Threading.Tasks;
+using Content.Server.Database;
+using NetCord;
+using NetCord.Rest;
+using Robust.Shared.Network;
+
+namespace Content.Server._Reserve.Discord;
+
+public sealed class DiscordLinkCog
+{
+    [Dependency] private readonly IServerDbManager _database = default!;
+
+    public DiscordLinkCog()
+    {
+        IoCManager.InjectDependencies(this);
+    }
+
+    public async Task<InteractionCallback> HandleAsync(string code, ulong discordUserId)
+    {
+        if (!Guid.TryParse(code, out var parsedCode))
+            return Ephemeral(Loc.GetString("discord-link-invalid-code"));
+
+        (LinkAccountCodeResult result, var playerId) = await _database.ConsumeLinkingCode(parsedCode, discordUserId, default);
+        switch (result)
+        {
+            case LinkAccountCodeResult.CodeNotFound:
+                return Ephemeral(Loc.GetString("discord-link-code-not-found"));
+            case LinkAccountCodeResult.CodeExpired:
+                return Ephemeral(Loc.GetString("discord-link-code-expired"));
+            case LinkAccountCodeResult.DiscordAlreadyLinked:
+                return Ephemeral(Loc.GetString("discord-link-discord-already-linked"));
+        }
+
+        var name = playerId is { } id
+            ? (await _database.GetPlayerRecordByUserId(id))?.LastSeenUserName ?? id.ToString()
+            : "?";
+
+        return Ephemeral(Loc.GetString("discord-link-success", ("player", name)));
+    }
+
+    private static InteractionCallback Ephemeral(string message)
+    {
+        return InteractionCallback.Message(new InteractionMessageProperties
+        {
+            Content = message,
+            Flags = MessageFlags.Ephemeral,
+        });
+    }
+}

--- a/Content.Server/_Reserve/Discord/DiscordProfileCog.cs
+++ b/Content.Server/_Reserve/Discord/DiscordProfileCog.cs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Text;
+using System.Threading.Tasks;
+using Content.Server.Administration;
+using Content.Server.Administration.Notes;
+using Content.Server.Database;
+using Content.Goobstation.Common.ServerCurrency;
+using Content.Shared.Preferences;
+using Content.Shared.Roles;
+using Content.Shared.CCVar;
+using Content.Shared.Humanoid.Prototypes;
+using Content.Goobstation.Shared.ServerCurrency;
+using NetCord;
+using NetCord.Rest;
+using Robust.Shared.Configuration;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+using System.Linq;
+
+namespace Content.Server._Reserve.Discord;
+
+public sealed class DiscordProfileCog
+{
+    [Dependency] private readonly IPlayerLocator _playerLocator = default!;
+    [Dependency] private readonly IServerDbManager _database = default!;
+    [Dependency] private readonly ICommonCurrencyManager _currency = default!;
+    [Dependency] private readonly IAdminNotesManager _notes = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly IConfigurationManager _configuration = default!;
+
+    // Patron/booster Discord roles shown next to a player's CKey, ordered highest-prestige first.
+    private static readonly CVarDef<string>[] BadgeRoleCVars =
+    [
+        CCVars.DiscordPatronRoleHonorary,
+        CCVars.DiscordPatronRoleTierX,
+        CCVars.DiscordPatronRoleTier5,
+        CCVars.DiscordPatronRoleTier4,
+        CCVars.DiscordPatronRoleTier3,
+        CCVars.DiscordPatronRoleTier2,
+        CCVars.DiscordPatronRoleTier1,
+        CCVars.DiscordBoosterRole,
+    ];
+
+    public DiscordProfileCog()
+    {
+        IoCManager.InjectDependencies(this);
+    }
+
+    public Task<InteractionCallback> HandleAsync(string command, string? player, ulong discordUserId, bool ephemeral, RestClient client, ulong guildId)
+    {
+        var part = command switch
+        {
+            "profile" => ProfilePart.All,
+            "balance" => ProfilePart.Balance,
+            "characters" => ProfilePart.Characters,
+            "inventory" => ProfilePart.Inventory,
+            _ => throw new InvalidOperationException($"Unknown profile command: {command}"),
+        };
+
+        return BuildResponse(player, part, discordUserId, ephemeral, client, guildId);
+    }
+
+    private async Task<InteractionCallback> BuildResponse(string? player, ProfilePart part, ulong discordUserId, bool ephemeral, RestClient client, ulong guildId)
+    {
+        NetUserId userId;
+        string ckey;
+        ulong? discordId;
+
+        if (string.IsNullOrWhiteSpace(player))
+        {
+            var linkedId = await _database.GetLinkedPlayerId(discordUserId, default);
+            if (linkedId == null)
+                return Respond(Loc.GetString("discord-profile-player-required"), ephemeral);
+
+            userId = linkedId.Value;
+            ckey = (await _database.GetPlayerRecordByUserId(userId))?.LastSeenUserName ?? userId.ToString();
+            discordId = discordUserId;
+        }
+        else if (TryParseUserId(player, out userId))
+        {
+            ckey = (await _database.GetPlayerRecordByUserId(userId))?.LastSeenUserName ?? player;
+            discordId = await _database.GetLinkedDiscordId(userId.UserId, default);
+        }
+        else
+        {
+            var located = await _playerLocator.LookupIdByNameOrIdAsync(player);
+            if (located == null)
+                return Respond(Loc.GetString("discord-profile-player-not-found", ("player", player)), ephemeral);
+
+            userId = located.UserId;
+            ckey = located.Username;
+            discordId = await _database.GetLinkedDiscordId(userId.UserId, default);
+        }
+
+        var title = await BuildTitle(ckey, discordId, client, guildId);
+        var preferences = await _database.GetPlayerPreferencesAsync(userId, default);
+        var description = new StringBuilder();
+
+        if (part is ProfilePart.All or ProfilePart.Characters)
+            AppendCharacters(description, preferences);
+        if (part is ProfilePart.All or ProfilePart.Balance)
+        {
+            description.AppendLine($"### {Loc.GetString("discord-profile-balance")}");
+            description.AppendLine(_currency.Stringify(_currency.GetBalance(userId)));
+        }
+        if (part is ProfilePart.All or ProfilePart.Inventory)
+            await AppendInventory(description, userId);
+
+        return Respond(new EmbedProperties
+        {
+            Title = title,
+            Description = description.Length == 0 ? Loc.GetString("discord-profile-no-data") : description.ToString(),
+            Color = new NetCord.Color(_configuration.GetCVar(CCVars.DiscordEmbedColor)),
+        }, ephemeral);
+    }
+
+    private static InteractionCallback Respond(string content, bool ephemeral)
+    {
+        return InteractionCallback.Message(new InteractionMessageProperties
+        {
+            Content = content,
+            Flags = ephemeral ? MessageFlags.Ephemeral : null,
+        });
+    }
+
+    private static InteractionCallback Respond(EmbedProperties embed, bool ephemeral)
+    {
+        return InteractionCallback.Message(new InteractionMessageProperties
+        {
+            Embeds = [embed],
+            Flags = ephemeral ? MessageFlags.Ephemeral : null,
+        });
+    }
+
+    // Builds the "Profile: <discord server name> (<ckey>), <badges>" title, or a "(not connected)" fallback.
+    private async Task<string> BuildTitle(string ckey, ulong? discordId, RestClient client, ulong guildId)
+    {
+        if (discordId == null)
+            return Loc.GetString("discord-profile-title-not-connected", ("player", ckey));
+
+        GuildUser member;
+        try
+        {
+            member = await client.GetGuildUserAsync(guildId, discordId.Value);
+        }
+        catch (RestException)
+        {
+            // Linked, but not a member of the guild (left, banned, etc.) or lookup otherwise failed.
+            return Loc.GetString("discord-profile-title-not-connected", ("player", ckey));
+        }
+
+        var serverName = member.Nickname ?? member.GlobalName ?? member.Username;
+
+        var ownedBadgeIds = BadgeRoleCVars
+            .Select(cvar => ulong.TryParse(_configuration.GetCVar(cvar), out var roleId) ? roleId : (ulong?) null)
+            .Where(roleId => roleId != null && member.RoleIds.Contains(roleId.Value))
+            .Select(roleId => roleId!.Value)
+            .ToArray();
+
+        var badges = string.Empty;
+        if (ownedBadgeIds.Length > 0)
+        {
+            var roles = await client.GetGuildRolesAsync(guildId);
+            var roleNames = roles.ToDictionary(role => role.Id, role => role.Name);
+
+            var sb = new StringBuilder();
+            foreach (var roleId in ownedBadgeIds)
+            {
+                if (roleNames.TryGetValue(roleId, out var roleName))
+                    sb.Append($", **{roleName}**");
+            }
+
+            badges = sb.ToString();
+        }
+
+        return Loc.GetString("discord-profile-title", ("player", serverName), ("ckey", ckey), ("badges", badges));
+    }
+
+    private void AppendCharacters(StringBuilder output, PlayerPreferences? preferences)
+    {
+        output.AppendLine($"### {Loc.GetString("discord-profile-characters")}");
+        if (preferences == null || preferences.Characters.Count == 0)
+        {
+            output.AppendLine(Loc.GetString("discord-profile-no-characters"));
+            return;
+        }
+
+        foreach (var (_, profile) in preferences.Characters.OrderBy(pair => pair.Key))
+        {
+            if (profile is not HumanoidCharacterProfile humanoid)
+                continue;
+
+            var highJob = humanoid.JobPriorities.FirstOrDefault(pair => pair.Value == JobPriority.High).Key;
+            var jobName = highJob.Id;
+            if (_prototypes.TryIndex(highJob, out JobPrototype? job))
+                jobName = Loc.GetString(job.Name);
+
+            var speciesName = humanoid.Species;
+            if (_prototypes.TryIndex<SpeciesPrototype>(humanoid.Species, out var species))
+                speciesName = Loc.GetString(species.Name);
+
+            output.AppendLine(Loc.GetString("discord-profile-character",
+                ("name", humanoid.Name),
+                ("age", humanoid.Age),
+                ("species", speciesName),
+                ("job", jobName)));
+        }
+    }
+
+    private async Task AppendInventory(StringBuilder output, NetUserId userId)
+    {
+        output.AppendLine($"### {Loc.GetString("discord-profile-inventory")}");
+        var tokenListings = _prototypes.EnumeratePrototypes<TokenListingPrototype>().ToArray();
+        var tokenMessages = tokenListings.ToDictionary(listing => Loc.GetString(listing.AdminNote));
+        var remarks = await _notes.GetAllAdminRemarks(userId.UserId);
+        var boughtTokens = remarks
+            .Where(remark => tokenMessages.ContainsKey(remark.Message))
+            .GroupBy(remark => tokenMessages[remark.Message])
+            .OrderBy(group => group.Key.ID);
+
+        if (!boughtTokens.Any())
+        {
+            output.AppendLine(Loc.GetString("discord-profile-no-tokens"));
+            return;
+        }
+
+        foreach (var token in boughtTokens)
+            output.AppendLine(Loc.GetString("discord-profile-token",
+                ("token", Loc.GetString(token.Key.Label)),
+                ("count", token.Count())));
+    }
+
+    private static bool TryParseUserId(string value, out NetUserId userId)
+    {
+        if (Guid.TryParse(value, out var guid))
+        {
+            userId = new NetUserId(guid);
+            return true;
+        }
+
+        userId = default;
+        return false;
+    }
+
+    private enum ProfilePart
+    {
+        All,
+        Balance,
+        Characters,
+        Inventory,
+    }
+}

--- a/Content.Shared/CCVar/CCVars.Discord.cs
+++ b/Content.Shared/CCVar/CCVars.Discord.cs
@@ -136,4 +136,66 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> DiscordOOCChatWebhook =
         CVarDef.Create("discord.ooc_webhook", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL | CVar.ARCHIVE);
+
+    // Reserve edit start: Full discord bot integration
+    /// <summary>
+    ///     Whether the "privately" option of the Discord profile commands defaults to true (ephemeral) when omitted.
+    /// </summary>
+    public static readonly CVarDef<bool> DiscordProfilePrivatelyDefault =
+        CVarDef.Create("discord.profile_privately_default", true, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Discord role ID for the honorary patron tier, shown next to a player's CKey in profile commands.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordPatronRoleHonorary =
+        CVarDef.Create("discord.patron_role_honorary", string.Empty, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Discord role ID for the highest patron tier.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordPatronRoleTierX =
+        CVarDef.Create("discord.patron_role_tier_x", string.Empty, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Discord role ID for the 5th patron tier.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordPatronRoleTier5 =
+        CVarDef.Create("discord.patron_role_tier_5", string.Empty, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Discord role ID for the 4th patron tier.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordPatronRoleTier4 =
+        CVarDef.Create("discord.patron_role_tier_4", string.Empty, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Discord role ID for the 3rd patron tier.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordPatronRoleTier3 =
+        CVarDef.Create("discord.patron_role_tier_3", string.Empty, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Discord role ID for the 2nd patron tier.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordPatronRoleTier2 =
+        CVarDef.Create("discord.patron_role_tier_2", string.Empty, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Discord role ID for the 1st patron tier.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordPatronRoleTier1 =
+        CVarDef.Create("discord.patron_role_tier_1", string.Empty, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Discord role ID for the server booster role.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordBoosterRole =
+        CVarDef.Create("discord.booster_role", string.Empty, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Embed line color for embedded discord bot responses.
+    /// </summary>
+    public static readonly CVarDef<int> DiscordEmbedColor =
+        CVarDef.Create("discord.embed_color", 0x992D22, CVar.SERVERONLY);
+    // Reserve edit end: Full discord bot integration
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     </PackageVersion>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.0" />
     <PackageVersion Include="NetCord" Version="1.0.0-alpha.388" />
+    <PackageVersion Include="NetCord.Services" Version="1.0.0-alpha.388" /> <!-- Reserve edit: Full discord bot integration -->
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageVersion Include="OpenTK" Version="4.9.4" />
     <PackageVersion Include="Veldrid" Version="4.8.0" />

--- a/Resources/Locale/en-US/_reserve/discord/link.ftl
+++ b/Resources/Locale/en-US/_reserve/discord/link.ftl
@@ -1,0 +1,5 @@
+discord-link-success = Linked to **{ $player }**.
+discord-link-invalid-code = That code doesn't look right. Copy it from the in-game linking window.
+discord-link-code-not-found = That code wasn't found. Request a new one from the in-game linking window.
+discord-link-code-expired = That code has expired. Request a new one from the in-game linking window.
+discord-link-discord-already-linked = This Discord account is already linked to a different player.

--- a/Resources/Locale/en-US/_reserve/discord/profile.ftl
+++ b/Resources/Locale/en-US/_reserve/discord/profile.ftl
@@ -1,0 +1,12 @@
+discord-profile-title = Profile: { $player } ({ $ckey }){ $badges }
+discord-profile-title-not-connected = Profile: { $player } (not connected)
+discord-profile-characters = Characters
+discord-profile-character = - **{ $name }** ({ $species }-{ $job }, { $age } y.o.)
+discord-profile-no-characters = No characters found.
+discord-profile-balance = Balance
+discord-profile-inventory = Bought tokens
+discord-profile-token = { $token } x{ $count }
+discord-profile-no-tokens = No tokens found.
+discord-profile-no-data = No profile data is available.
+discord-profile-player-not-found = No player found for `{ $player }`.
+discord-profile-player-required = Specify a player, or link your account with /link.

--- a/Resources/Locale/ru-RU/_reserve/discord/link.ftl
+++ b/Resources/Locale/ru-RU/_reserve/discord/link.ftl
@@ -1,0 +1,5 @@
+discord-link-success = Привязано к **{ $player }**.
+discord-link-invalid-code = Код выглядит некорректно. Скопируйте его из окна привязки аккаунта в игре.
+discord-link-code-not-found = Код не найден. Запросите новый в окне привязки аккаунта в игре.
+discord-link-code-expired = Срок действия кода истёк. Запросите новый в окне привязки аккаунта в игре.
+discord-link-discord-already-linked = Этот аккаунт Discord уже привязан к другому игроку.

--- a/Resources/Locale/ru-RU/_reserve/discord/profile.ftl
+++ b/Resources/Locale/ru-RU/_reserve/discord/profile.ftl
@@ -1,0 +1,12 @@
+discord-profile-title = Профиль: { $player } ({ $ckey }){ $badges }
+discord-profile-title-not-connected = Профиль: { $player } (не привязан)
+discord-profile-characters = Персонажи
+discord-profile-character = - **{ $name }** ({ $species }-{ $job }, { $age } лет)
+discord-profile-no-characters = Персонажи не найдены.
+discord-profile-balance = Баланс
+discord-profile-inventory = Токены
+discord-profile-token = { $token } x{ $count }
+discord-profile-no-tokens = Токены не найдены.
+discord-profile-no-data = Данные профиля отсутствуют.
+discord-profile-player-not-found = Игрок с идентификатором `{ $player }` не найден.
+discord-profile-player-required = Укажите игрока или привяжите свой аккаунт через /link.


### PR DESCRIPTION
# Описание PR

Добавляет доп. интеграцию с Дискордом. В изменения входят:

- привязка аккаунта Дискорда к аккаунту игры:
  - привязать свой аккаунт можно, нажав на кнопку привязки в Лобби, вверху слева.
- 4 команды для проверки профиля любого игрока:
  - если привязан аккаунт, можно использовать команды на себя, не указывая каждый раз свой сикей;
  - по умолчанию ответ виден только использовавшему команду, но это можно изменить указав опциональный параметр в `True`.

## Изменения

:cl:
- add: Привязка аккаунта к аккаунту Discord. Нажмите на кнопку привязки в Лобби, скопируйте код и используйте команду /link бота на сервере.
- add: Просмотр базовой информации о себе и других игроках вне игры, через бота.
