### PR TITLE
Better trinket loadout for antags

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -29,7 +29,10 @@ using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
 using Content.Shared.Mind;
 using Content.Shared.Players;
+using Content.Shared.Preferences;  // Reserve edit: Antag loadouts
+using Content.Shared.Preferences.Loadouts;  // Reserve edit: Antag loadouts
 using Content.Shared.Roles;
+using Content.Shared.Station;  // Reserve edit: Antag loadouts
 using Content.Shared.Whitelist;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
@@ -63,6 +66,9 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     [Dependency] private readonly PlayTimeTrackingManager _playTimeManager = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly ArrivalsSystem _arrivals = default!;
+    [Dependency] private readonly SharedStationSpawningSystem _spawningSystem = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
     // arbitrary random number to give late joining some mild interest.
     public const float LateJoinRandomChance = 0.5f;
@@ -522,7 +528,51 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         if (def.StartingGear is not null)
             gear.Add(def.StartingGear.Value);
 
-        _loadout.Equip(player, gear, def.RoleLoadout);
+        _loadout.Equip(player, gear, null);  // Reserve edit: Antag loadouts
+
+        // Reserve edit start: Antag loadouts - actually respect antag loadouts
+        if (def.RoleLoadout != null)
+        {
+            var jobProtoId = _random.Pick(def.RoleLoadout);
+            HumanoidCharacterProfile? profile = null;
+            // Check if we are setting the outfit of a player to respect the preferences
+            if (EntityManager.TryGetComponent(player, out ActorComponent? actorComponent))
+            {
+                session = actorComponent.PlayerSession;
+                var userId = actorComponent.PlayerSession.UserId;
+                var prefs = _pref.GetPreferences(userId);
+                profile = prefs.SelectedCharacter as HumanoidCharacterProfile;
+            }
+            // Don't require a player, so this works on Urists
+            profile ??= EntityManager.TryGetComponent<HumanoidAppearanceComponent>(player, out var comp)
+                ? HumanoidCharacterProfile.DefaultWithSpecies(comp.Species)
+                : new HumanoidCharacterProfile();
+            // Try to get the user's existing loadout for the role
+            profile.Loadouts.TryGetValue(jobProtoId, out var roleLoadout);
+
+            if (roleLoadout == null)
+            {
+                // If they don't have a loadout for the role, make a default one
+                roleLoadout = new RoleLoadout(jobProtoId);
+                roleLoadout.SetDefault(profile, session, _prototypeManager);
+            }
+
+            // Order loadout selections by the order they appear on the prototype.
+            foreach (var group in roleLoadout.SelectedLoadouts)
+            {
+                foreach (var items in group.Value)
+                {
+                    if (!_prototypeManager.TryIndex(items.Prototype, out var loadoutProto))
+                    {
+                        Log.Error($"Unable to find loadout prototype for {items.Prototype}");
+                        continue;
+                    }
+
+                    _spawningSystem.EquipStartingGear(player, loadoutProto, raiseEvent: false);
+                }
+            }
+        }
+        // Reserve edit end: Antag loadouts
 
         if (session != null)
         {

--- a/Resources/Locale/ru-RU/_reserve/loadouts/Miscellaneous/corporate.ftl
+++ b/Resources/Locale/ru-RU/_reserve/loadouts/Miscellaneous/corporate.ftl
@@ -1,0 +1,30 @@
+ent-FoodSnackLollypopNocturineCorporateAgent = леденец
+    .desc = Обычный леденец. Этот очень сахарный.
+    .suffix = Лодаут, Безделушки, Корпоративный агент, ЦентКом, Ноктюрин
+ent-FoodSnackLollypopNocturineCorporateAgentDummy = три корпоративных леденца с ноктюрином
+    .desc = { ent-FoodSnackLollypopNocturineCorporateAgent.desc }
+
+ent-FoodSnackLollypopWrappedCentCommDummy = три леденца ЦентКом
+    .desc = { ent-FoodSnackLollypopWrappedCentComm.desc }
+
+ent-TowelColorCorporate = корпоративное полотенце
+    .desc = { ent-BaseTowel.desc }
+    .suffix = Лодаут, Безделушки, Корпоративный агент, ЦентКом
+
+ent-RingCorporateAgent = корпоративное кольцо
+    .desc = { ent-PlasticRing.desc }
+    .suffix = Лодаут, Безделушки, Корпоративный агент, ЦентКом
+
+ent-PenAICorporateAgent = корпоративная смартручка
+    .desc = Ваша корпоративная смартручка! Что-то в ней кажется странным...
+    .suffix = Лодаут, Безделушки, Корпоративный агент, ЦентКом, Персональный ИИ, Роль призрака
+
+ent-DiskCaseCorporateAgent = корпоративный кейс для CD-дисков
+    .desc = Очень интересный футляр для дисков. Похоже, у него есть двойное дно для дополнительных дисков.
+    .suffix = Лодаут, Безделушки, Корпоративный агент, ЦентКом
+
+doc-text-suicide-note-blob =
+    Мне... очень плохо. Я чувствую, будто что-то как будто...
+    Как будто пытается вырваться наружу?..
+    Это невыносимо...
+    Не ищите меня. Мне кажется, уже слишком поздно...

--- a/Resources/Locale/ru-RU/_reserve/loadouts/Miscellaneous/syndicate.ftl
+++ b/Resources/Locale/ru-RU/_reserve/loadouts/Miscellaneous/syndicate.ftl
@@ -1,0 +1,23 @@
+ent-RagItemBloodRed = кроваво-красная { ent-RagItem }
+    .desc = На такой не будут видны пятна настоящей крови. Наверное.
+    .suffix = Лодаут, Безделушки, Синдикат
+
+ent-CigarCaseBloodRed = кроваво-красный { ent-CigarCase }
+    .desc = Когда ты здесь чтобы курить сигару и драть задницы.
+    .suffix = Лодаут, Безделушки, Синдикат
+
+ent-FoodSnackLollypopSyndicateDummy = три кроваво-красных леденца
+    .desc = { ent-FoodSnackLollypopSyndicate.desc }
+
+ent-SyndicateTennisRacketTwoDummy = две кроваво-красные ракетки
+    .desc = { ent-SyndicateTennisRacket.desc }
+
+ent-d6DiceBloodRed = кроваво-красная { ent-d6Dice }
+    .desc = Эти кубики решают судьбы других.
+    .suffix = Лодаут, Безделушки, Синдикат, { ent-d6Dice.suffix }
+ent-d6DiceBloodRedTwoDummy = два кроваво-красных кубика
+    .desc = { ent-d6DiceBloodRed.desc }
+
+ent-NukieRing = нюкольцо
+    .desc = { ent-PlasticRing.desc }
+    .suffix = Лодаут, Безделушки, Синдикат

--- a/Resources/Locale/ru-RU/_reserve/loadouts/Miscellaneous/thief.ftl
+++ b/Resources/Locale/ru-RU/_reserve/loadouts/Miscellaneous/thief.ftl
@@ -1,0 +1,28 @@
+ent-RagItemBlack = чёрная { ent-RagItem }
+    .desc = На такой не будут видны отпечатки пальцев. Наверное.
+    .suffix = Лодаут, Безделушки, Вор
+
+ent-FlippoThief = чёрный флиппо
+    .desc = Похоже он был у кого-то украден.
+    .suffix = Лодаут, Безделушки, Вор, Зажигалка
+
+ent-CigarCaseBlack = чёрный { ent-CigarCase }
+    .desc = Когда ты хочешь оставить за собой лишь стильный дымный хвост.
+    .suffix = Лодаут, Безделушки, Вор
+
+ent-CrayonBlackThiefDummy = четыре чёрных мелка
+    .desc = { ent-CrayonBlack.desc }
+
+ent-d6DiceBlack = чёрная { ent-d6Dice }
+    .desc = На ней вообще видно стороны?
+    .suffix = Лодаут, Безделушки, Вор, { ent-d6Dice.suffix }
+ent-d6DiceBlackTwoDummy = два чёрных кубика
+    .desc = { ent-d6DiceBlack.desc }
+
+ent-BlackRing = чёрное кольцо
+    .desc = { ent-PlasticRing.desc }
+    .suffix = Лодаут, Безделушки, Вор
+
+ent-ClothingNeckTieThief = чёрный галстук
+    .desc = Выглядит украденным...
+    .suffix = Лодаут, Безделушки, Вор

--- a/Resources/Locale/ru-RU/_reserve/loadouts/Miscellaneous/wizard.ftl
+++ b/Resources/Locale/ru-RU/_reserve/loadouts/Miscellaneous/wizard.ftl
@@ -1,0 +1,30 @@
+ent-FoodSnackLollypopWizard = волшебный леденец
+    .desc = Леденец, наполненный особым магическим коктейлем.
+    .suffix = Лодаут, Безделушки, Волшебник
+ent-FoodSnackLollypopWizardDummy = три волшебных леденца
+    .desc = { ent-FoodSnackLollypopWizard.desc }
+
+ent-FoodSnackLollypopWrappedMysteryDummy = три загадочных леденца
+    .desc = { ent-FoodSnackLollypopWrappedMystery.desc }
+
+ent-FoodSnackLollypopRainbowWizard = радужный леденец
+    .desc = Зачарованный леденец. Что может пойти не так?
+    .suffix = Лодаут, Безделушки, Волшебник
+ent-FoodSnackLollypopRainbowWizardDummy = три радужных леденца
+    .desc = { ent-FoodSnackLollypopRainbowWizard.desc }
+
+ent-TowelColorWizard = полотенце волшебника
+    .desc = { ent-BaseTowel.desc }
+    .suffix = Лодаут, Безделушки, Волшебник
+
+ent-RingWizard = кольцо волшебника
+    .desc = { ent-PlasticRing.desc }
+    .suffix = Лодаут, Безделушки, Волшебник
+
+ent-LeftHandSkeletonNecromancer = рука некроманта
+    .desc = Рука скелета, используемая некромантами для бог знает чего. Говорят, что этой рукой можно призывать мёртвых. Но похоже, что эта разрядилась?.. У кого-нибудь есть зарядка?..
+    .suffix = Лодаут, Безделушки, Волшебник, Левая рука, Скелет
+
+ent-HeadSkeletonRainbow = радужный череп
+    .desc = Почему волшебники делают всё радужным?..
+    .suffix = Лодаут, Безделушки, Волшебник, Скелет, Роль призрака

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -26,6 +26,8 @@
       allowNonHumans: true
       multiAntagSetting: NotExclusive
       startingGear: ThiefGear
+      roleLoadout:
+      - AntagThief
       jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist: # GOOBSTATION
         components:

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -21,6 +21,6 @@
   storage:
     back:
     - ThiefBeacon
-    - SatchelThief
+    # - SatchelThief  # Reserve edit: Antag Trinkets
     # - ClothingHandsChameleonThief - Goobedit, since thieves have intrinsic pickpocketing now we don't need these
     - PinpointerThief # Goob edit

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -406,6 +406,8 @@
       allowNonHumans: true
       multiAntagSetting: NotExclusive
       startingGear: ThiefGear
+      roleLoadout:
+      - AntagThief
       components:
       - type: Pacified
       - type: Thieving

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts_antag.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts_antag.yml
@@ -2,3 +2,4 @@
   id: AntagTraitor
   groups:
   - TraitorUplink
+  - TrinketsSyndicate  # Reserve edit: Antag Trinkets

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -27,7 +27,8 @@
       startingGear: WizardGear
       unequipOldGear: true
       roleLoadout:
-      - RoleSurvivalEVA
+      # - RoleSurvivalEVA
+      - AntagWizard
       components:
       - type: Wizard
       - type: CanEnchant
@@ -85,7 +86,8 @@
       startingGear: WizardGear
       unequipOldGear: true
       roleLoadout:
-      - RoleSurvivalEVA
+      # - RoleSurvivalEVA
+      - AntagWizard
       components:
       - type: Wizard
       - type: RandomMetadata

--- a/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/blob.yml
+++ b/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/blob.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: roleLoadout
+  id: AntagBlob
+  groups:
+  - TrinketsBlob
+
+- type: loadoutGroup
+  id: TrinketsBlob
+  name: loadout-group-trinkets
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - PaperSuicideNoteBlob
+
+# region Bones
+
+- type: entity
+  parent: Paper
+  id: PaperSuicideNoteBlob
+  name: suicide note
+  suffix: Loadout, Trinkets, Blob
+  components:
+    - type: Paper
+      content: doc-text-suicide-note-blob
+
+- type: loadout
+  id: PaperSuicideNoteBlob
+  storage:
+    back:
+    - PaperSuicideNoteBlob
+
+# endregion

--- a/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/corporate.yml
+++ b/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/corporate.yml
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: roleLoadout
+  id: AntagCorporateAgent
+  groups:
+  - TrinketsCorporateAgent
+
+- type: loadoutGroup
+  id: TrinketsCorporateAgent
+  name: loadout-group-trinkets
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - PenAICorporateAgent
+  - FoodSnackLollypopNocturineCorporateAgent
+  - TowelCorporateAgent
+  - TowelColorCentcom
+  - TowelColorNT
+  - RingCorporateAgent
+  - DiskCaseCorporateAgent
+  - BalloonNT
+  - CardBoxNanotrasen
+  - FoodSnackLollypopCentComm
+  - BedsheetCentComm
+  - BoxFolderCentComm
+  - BoxFolderClipboardCentComm
+  - BusinessCardCentComm
+  # - ???
+  # - ???
+
+# region Towel
+
+- type: entity
+  parent: BaseTowel
+  id: TowelColorCorporate
+  name: corporate towel
+  suffix: Loadout, Trinkets, Corporate Agent, CentComm
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#29722e"
+    - state: NTmono
+      color: "#F7C430"
+    - state: iconstripe
+      color: "#940000"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#29722e"
+      right:
+      - state: inhand-right
+        color: "#29722e"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#29722e"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#29722e"
+      belt:
+      - state: equipped-BELT
+        color: "#29722e"
+  - type: Fiber
+    fiberColor: fibers-green
+
+- type: loadout
+  id: TowelCorporateAgent
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 30h
+  storage:
+    back:
+    - TowelColorCorporate
+  groupBy: "towels"
+
+# endregion
+
+# region Candy
+
+- type: entity
+  parent: FoodSnackLollypopNocturine
+  id: FoodSnackLollypopNocturineCorporateAgent
+  name: lollypop
+  description: A plain old lollypop. It's very sugary.
+  suffix: Loadout, Trinkets, Corporate Agent, CentComm, Nocturine
+  components:
+  - type: Sprite
+    layers:
+    - state: lollypop
+      map: [ "enum.AmmoVisualLayers.Base" ]
+    - state: color
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+      color: "#29722e"
+
+- type: entity
+  parent: FoodSnackLollypopNocturineCorporateAgent
+  id: FoodSnackLollypopNocturineCorporateAgentDummy
+  categories: [ HideSpawnMenu ]
+  name: three corporate nocturine lollypops
+  components:
+  - type: Sprite
+    layers:
+    - state: lollypop
+      map: [ "enum.AmmoVisualLayers.Base" ]
+      offset: 0, -0.25
+    - state: color
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+      color: "#29722e"
+      offset: 0, -0.25
+    - state: lollypop
+      offset: -0.1, 0.1
+    - state: color
+      color: "#29722e"
+      offset: -0.1, 0.1
+    - state: lollypop
+      offset: 0.25, 0
+    - state: color
+      color: "#29722e"
+      offset: 0.25, 0
+
+- type: loadout
+  id: FoodSnackLollypopNocturineCorporateAgent
+  dummyEntity: FoodSnackLollypopNocturineCorporateAgentDummy
+  storage:
+    back:
+    - FoodSnackLollypopNocturineCorporateAgent
+    - FoodSnackLollypopNocturineCorporateAgent
+    - FoodSnackLollypopNocturineCorporateAgent
+  groupBy: "candy"
+
+# endregion
+
+# region Other
+
+- type: entity
+  parent: FakeDiamondRing
+  id: RingCorporateAgent
+  name: corporate ring
+  suffix: Loadout, Trinkets, Corporate Agent, CentComm
+  components:
+  - type: Sprite
+    layers:
+      - state: ring
+        color: "#29722e"
+      - state: gem
+        color: "#940000"
+
+- type: loadout
+  id: RingCorporateAgent
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 150h
+  storage:
+    back:
+    - RingCorporateAgent
+  groupBy: "ring"
+
+- type: entity
+  parent: [PenCentcom, PersonalAI]
+  id: PenAICorporateAgent
+  name: corporate smartpen
+  description: Your corporate pen-pal! Something seems off about it though...
+  suffix: Loadout, Trinkets, Corporate Agent, CentComm, Personal AI, Ghost Role
+  components:
+  - type: Sprite
+    layers: []
+  - type: GenericVisualizer
+    visuals: {}
+
+- type: loadout
+  id: PenAICorporateAgent
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Silicon
+      time: 1h
+  storage:
+    back:
+    - PenAICorporateAgent
+
+- type: entity
+  parent: DiskCase
+  id: DiskCaseCorporateAgent
+  name: corporate disk case
+  description: A very interesting disk case. Seems to have a double bottom for extra discs.
+  suffix: Loadout, Trinkets, Corporate Agent, CentComm
+  components:
+  - type: Sprite
+    color: "#29722e"
+  - type: Storage
+    grid:
+    - 0,0,0,3
+  groupBy: "audio"
+
+- type: loadout
+  id: DiskCaseCorporateAgent
+  storage:
+    back:
+    - DiskCaseCorporateAgent
+
+# endregion
+
+# region CentCom
+
+- type: entity
+  parent: FoodSnackLollypopWrappedCentComm
+  id: FoodSnackLollypopWrappedCentCommDummy
+  categories: [ HideSpawnMenu ]
+  name: three CentComm lollypops
+  components:
+  - type: Sprite
+    layers:
+    - state: lollypop-wrapped-centcomm
+      offset: 0, -0.25
+    - state: lollypop-wrapped-centcomm
+      offset: -0.1, 0.1
+    - state: lollypop-wrapped-centcomm
+      offset: 0.25, 0
+
+- type: loadout
+  id: FoodSnackLollypopCentComm
+  dummyEntity: FoodSnackLollypopWrappedCentCommDummy
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChef
+      time: 45h
+  storage:
+    back:
+    - FoodSnackLollypopWrappedCentComm
+    - FoodSnackLollypopWrappedCentComm
+    - FoodSnackLollypopWrappedCentComm
+  groupBy: "candy"
+
+- type: loadout
+  id: BedsheetCentComm
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 40h
+  storage:
+    back:
+    - BedsheetCentcom
+
+- type: loadout
+  id: BoxFolderCentComm
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 60h
+  storage:
+    back:
+    - BoxFolderCentComThreePapers
+  groupBy: "folders"
+
+- type: loadout
+  id: BoxFolderClipboardCentComm
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 80h
+  storage:
+    back:
+    - BoxFolderCentComClipboardThreePapers
+  groupBy: "folders"
+
+# - type: loadout
+#   id: PenCentComm
+#   effects:
+#   - !type:JobRequirementLoadoutEffect
+#     requirement:
+#       !type:OverallPlaytimeRequirement
+#       time: 100h
+#   storage:
+#     back:
+#     - PenCentcom
+
+- type: loadout
+  id: BusinessCardCentComm
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 100h
+  storage:
+    back:
+    - CentralCommandBusinessCard
+
+# endregion

--- a/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/devil.yml
+++ b/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/devil.yml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: roleLoadout
+  id: AntagDevil
+  groups:
+  - TrinketsDevil
+
+- type: loadoutGroup
+  id: TrinketsDevil
+  name: loadout-group-trinkets
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - SkullBloodRed
+
+# region Bones
+
+- type: entity
+  parent: HeadSkeleton
+  id: HeadSkeletonBloodRed
+  name: blood-red skull
+  description: Looks like it's fairly fresh...
+  suffix: Loadout, Trinkets, Devil, Demon, Syndicate
+  components:
+  - type: Sprite
+    state: "skull_icon"
+    color: "#940000"
+
+- type: loadout
+  id: SkullBloodRed
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChaplain
+      time: 15h
+  storage:
+    back:
+    - HeadSkeletonBloodRed
+  groupBy: "skulls"
+
+# endregion

--- a/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/pirate.yml
+++ b/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/pirate.yml
@@ -1,0 +1,5 @@
+
+
+# ClothingHeadHatHetmanHat
+# ClothingHeadHatGreyFlatcap
+# ClothingHeadHatCasa

--- a/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/syndicate.yml
+++ b/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/syndicate.yml
@@ -1,0 +1,441 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: roleLoadout
+  id: AntagContractor
+  groups:
+  - TrinketsSyndicate
+
+- type: roleLoadout
+  id: AntagNukeops
+  groups:
+  - TrinketsSyndicate
+
+- type: roleLoadout
+  id: AntagNukeopsMedic
+  groups:
+  - TrinketsSyndicate
+
+- type: roleLoadout
+  id: AntagNukeopsCommander
+  groups:
+  - TrinketsSyndicate
+
+- type: loadoutGroup
+  id: TrinketsSyndicate
+  name: loadout-group-trinkets
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - RagSyndicate
+  - FoodSnackLollypopSyndicate
+  - DrinkMugSyndicate
+  - TennisRacketSyndicate
+  - BalloonSyndicate
+  - d6DiceSyndicate
+  - CardBoxSyndicate
+  - CassetteSyndicate
+  - CdDiskSyndicate
+  - BusinessCardSyndicate
+  - FolderSyndicate
+  - TowelSyndicate
+  - TowelSyndicateRed
+  - TowelSyndicateGreen
+  - TowelSyndicateBlack
+  - FlippoSyndicate
+  - CigarCaseSyndicate
+  - NukieRing
+  - PlushieNuke
+  - NukieCan
+
+# region Rag
+
+- type: entity
+  parent: RagItem
+  id: RagItemBloodRed
+  name: blood-red rag
+  description: Would be hard to spot actual blood stains on this one.
+  suffix: Loadout, Trinkets, Syndicate
+  components:
+  - type: Sprite
+    layers:
+    - state: rag
+      color: "#940000"
+    - map: ["enum.SolutionContainerLayers.Fill"]
+      state: fill-3
+      visible: false
+
+- type: loadout
+  id: RagSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobBartender
+      time: 25h
+  storage:
+    back:
+    - RagItemBloodRed
+  groupBy: "misc"
+
+# endregion
+
+# region Drinks
+
+- type: loadout
+  id: NukieCan
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 300h
+  storage:
+    back:
+    - DrinkNukieCan
+  groupBy: "drinks"
+
+- type: loadout
+  id: DrinkMugSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 35h
+  storage:
+    back:
+    - DrinkMugRed
+  groupBy: "drinks"
+
+# endregion
+
+# region Lighter
+
+- type: loadout
+  id: FlippoSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 200h
+  storage:
+    back:
+    - SyndicateFlippo
+  groupBy: "smokeables"
+
+- type: entity
+  id: CigarCaseBloodRed
+  parent: CigarCase
+  name: blood-red cigar case
+  description: For when you came to smoke cigars and kick ass.
+  suffix: Loadout, Trinkets, Syndicate
+  components:
+  - type: Sprite
+    color: "#940000"
+
+- type: loadout
+  id: CigarCaseSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 250h
+  storage:
+    back:
+    - CigarCaseBloodRed
+  groupBy: "smokeables"
+
+# endregion
+
+# region Candy
+
+- type: entity
+  parent: FoodSnackLollypopSyndicate
+  id: FoodSnackLollypopSyndicateDummy
+  categories: [ HideSpawnMenu ]
+  name: three blood-red lollypops
+  components:
+  - type: Sprite
+    layers:
+    - state: lollypop
+      map: [ "enum.AmmoVisualLayers.Base" ]
+      offset: 0, -0.25
+    - state: color
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+      color: "#810e0e"
+      offset: 0, -0.25
+    - state: lollypop
+      offset: -0.1, 0.1
+    - state: color
+      color: "#810e0e"
+      offset: -0.1, 0.1
+    - state: lollypop
+      offset: 0.25, 0
+    - state: color
+      color: "#810e0e"
+      offset: 0.25, 0
+
+- type: loadout
+  id: FoodSnackLollypopSyndicate
+  dummyEntity: FoodSnackLollypopSyndicateDummy
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChef
+      time: 35h
+  storage:
+    back:
+    - FoodSnackLollypopWrappedSyndicate
+    - FoodSnackLollypopWrappedSyndicate
+    - FoodSnackLollypopWrappedSyndicate
+  groupBy: "candy"
+
+# endregion
+
+# region Sports
+
+- type: entity
+  parent: SyndicateTennisRacket
+  id: SyndicateTennisRacketTwoDummy
+  categories: [ HideSpawnMenu ]
+  name: two Syndicate tennis rackets
+
+- type: loadout
+  id: TennisRacketSyndicate
+  dummyEntity: SyndicateTennisRacketTwoDummy
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobBoxer
+      time: 5h
+  storage:
+    back:
+    - SyndicateTennisRacket
+    - SyndicateTennisRacket
+  groupBy: "cards"
+
+# endregion
+
+# region Toys
+
+- type: loadout
+  id: BalloonSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 80h
+  storage:
+    back:
+    - BalloonSyn
+  groupBy: "cards"
+
+- type: loadout
+  id: PlushieNuke
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 120h
+  storage:
+    back:
+    - PlushieNuke
+  groupBy: "plushies"
+
+- type: loadout
+  id: CardBoxSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 100h
+  storage:
+    back:
+    - CardBoxSyndicate
+  groupBy: "cards"
+
+# endregion
+
+# region Audio
+
+- type: loadout
+  id: CassetteSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 180h
+  storage:
+    back:
+    - BloodredCassette
+  groupBy: "audio"
+
+- type: loadout
+  id: CdDiskSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobRadioHost
+      time: 10h
+  storage:
+    back:
+    - JVNECdDiskSyndicate
+  groupBy: "audio"
+
+# endregion
+
+# region Dice
+
+- type: entity
+  parent: d6Dice
+  id: d6DiceBloodRed
+  name: blood-red d6
+  description: These dice decide the fates of others.
+  suffix: Loadout, Trinkets, Syndicate
+  components:
+  - type: Sprite
+    color: "#940000"
+
+- type: entity
+  parent: d6DiceBloodRed
+  id: d6DiceBloodRedTwoDummy
+  categories: [ HideSpawnMenu ]
+  name: two blood-red dice
+  components:
+  - type: Sprite
+    layers:
+    - state: d6_6
+      color: "#940000"
+      offset: -0.1, -0.15
+    - state: d6_6
+      color: "#940000"
+      offset: 0.15, 0.1
+
+- type: loadout
+  id: d6DiceSyndicate
+  dummyEntity: d6DiceBloodRedTwoDummy
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Cargo
+      time: 60h
+  storage:
+    back:
+    - d6DiceBloodRed
+    - d6DiceBloodRed
+  groupBy: "cards"
+
+# endregion
+
+# region BusinessCard
+
+- type: loadout
+  id: BusinessCardSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 100h
+  storage:
+    back:
+    - SyndicateBusinessCard
+  groupBy: "folders"
+
+- type: loadout
+  id: FolderSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Command
+      time: 30h
+  storage:
+    back:
+    - BoxFolderRedThreePapers
+  groupBy: "folders"
+
+# endregion
+
+# region Towel
+
+- type: loadout
+  id: TowelSyndicate
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 20h
+  storage:
+    back:
+    - TowelColorSyndicate
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelSyndicateRed
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobRoboticist
+      time: 20h
+  storage:
+    back:
+    - TowelColorRed
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelSyndicateGreen
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 40h
+  storage:
+    back:
+    - TowelColorDarkGreen
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelSyndicateBlack
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 60h
+  storage:
+    back:
+    - TowelColorBlack
+  groupBy: "towels"
+
+# endregion
+
+# region Jewelry
+
+- type: entity
+  parent: PlasticRing
+  id: NukieRing
+  name: nukiering
+  suffix: Loadout, Trinkets, Syndicate
+  components:
+  - type: Sprite
+    layers:
+      - state: ring
+        color: "#940000"
+      - state: gem
+        color: "#44aa22"
+
+- type: loadout
+  id: NukieRing
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 150h
+  storage:
+    back:
+    - NukieRing
+  groupBy: "ring"
+
+# endregion

--- a/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/thief.yml
+++ b/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/thief.yml
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: roleLoadout
+  id: AntagThief
+  groups:
+  - BagThief
+  - NeckThief
+  - TrinketsThief
+
+- type: loadoutGroup
+  id: TrinketsThief
+  name: loadout-group-trinkets
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - RagThief
+  - DrinkMugThief
+  - FlippoThief
+  - CigarCaseThief
+  - CardBoxThief
+  - d6DiceThief
+  - CrayonThief
+  - FolderThief
+  - TowelThief
+  - RingThief
+  - HeadBandThief
+  - CatHatThief
+
+- type: loadoutGroup
+  id: NeckThief
+  name: lathe-category-neck
+  minLimit: 0
+  maxLimit: 1
+  loadouts:
+  - MaskThief
+  - TieThief
+  - GaiterThief
+  - PonchoThief
+  - PonchoSmallThief
+  - ScarfThief
+
+- type: loadoutGroup
+  id: BagThief
+  name: loadout-group-instruments
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - SatchelThief
+  - ToolboxThief
+
+# region Bag
+
+- type: loadout
+  id: SatchelThief
+  storage:
+    back:
+    - SatchelThief
+
+- type: loadout
+  id: ToolboxThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 50h
+  storage:
+    back:
+    - ToolboxThief
+
+# region Rag
+
+- type: entity
+  parent: RagItem
+  id: RagItemBlack
+  name: black rag
+  description: Would be hard to spot fingerprints on this one.
+  suffix: Loadout, Trinkets, Thief
+  components:
+  - type: Sprite
+    layers:
+    - state: rag
+      color: "#535353"
+    - map: ["enum.SolutionContainerLayers.Fill"]
+      state: fill-3
+      visible: false
+
+- type: loadout
+  id: RagThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobBartender
+      time: 25h
+  storage:
+    back:
+    - RagItemBlack
+  groupBy: "misc"
+
+# endregion
+
+# region Drinks
+
+- type: loadout
+  id: DrinkMugThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 35h
+  storage:
+    back:
+    - DrinkMugBlack
+  groupBy: "drinks"
+
+# endregion
+
+# region Lighter
+
+- type: entity
+  parent: SpiderclanFlippo
+  id: FlippoThief
+  name: black flippo
+  description: Seems like it was stolen from someone.
+  suffix: Loadout, Trinkets, Thief, Lighter
+
+- type: loadout
+  id: FlippoThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 300h
+  storage:
+    back:
+    - FlippoThief
+  groupBy: "smokeables"
+
+- type: entity
+  parent: CigarCase
+  id: CigarCaseBlack
+  name: black cigar case
+  description: For when you when you want to leave a classy smoketrail.
+  suffix: Loadout, Trinkets, Thief
+  components:
+  - type: Sprite
+    color: "#535353"
+
+- type: loadout
+  id: CigarCaseThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 250h
+  storage:
+    back:
+    - CigarCaseBlack
+  groupBy: "smokeables"
+
+# endregion
+
+# region Toys
+
+- type: loadout
+  id: CardBoxThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 100h
+  storage:
+    back:
+    - CardBoxBlack
+  groupBy: "cards"
+
+- type: entity
+  parent: CrayonBlack
+  id: CrayonBlackThiefDummy
+  categories: [ HideSpawnMenu ]
+  name: four black crayons
+  components:
+  - type: Sprite
+    layers:
+    - state: black
+      offset: 0, -0.25
+    - state: black
+      offset: 0.1, 0.25
+    - state: black
+      offset: -0.25, 0
+    - state: black
+      offset: 0.35, 0
+
+- type: loadout
+  id: CrayonThief
+  dummyEntity: CrayonBlackThiefDummy
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobMime
+      time: 30h
+  storage:
+    back:
+    - CrayonBlack
+    - CrayonBlack
+    - CrayonBlack
+    - CrayonBlack
+  groupBy: "cards"
+
+# endregion
+
+# region Dice
+
+- type: entity
+  parent: d6Dice
+  id: d6DiceBlack
+  name: black d6
+  description: Can you even see the sides?
+  suffix: Loadout, Trinkets, Thief
+  components:
+  - type: Sprite
+    color: "#535353"
+
+- type: entity
+  parent: d6DiceBlack
+  id: d6DiceBlackTwoDummy
+  categories: [ HideSpawnMenu ]
+  name: two black dice
+  components:
+  - type: Sprite
+    layers:
+    - state: d6_6
+      color: "#939393"
+      offset: -0.1, -0.15
+    - state: d6_6
+      color: "#939393"
+      offset: 0.15, 0.1
+
+- type: loadout
+  id: d6DiceThief
+  dummyEntity: d6DiceBlackTwoDummy
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Cargo
+      time: 60h
+  storage:
+    back:
+    - d6DiceBlack
+    - d6DiceBlack
+  groupBy: "cards"
+
+# endregion
+
+# region Paper
+
+- type: loadout
+  id: FolderThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Command
+      time: 30h
+  storage:
+    back:
+    - BoxFolderBlackThreePapers
+  groupBy: "folders"
+
+# endregion
+
+# region Towel
+
+- type: loadout
+  id: TowelThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 30h
+  storage:
+    back:
+    - TowelColorBlack
+  groupBy: "towels"
+
+# endregion
+
+# region Jewelry
+
+- type: entity
+  parent: PlasticRing
+  id: BlackRing
+  name: black ring
+  suffix: Loadout, Trinkets, Thief
+  components:
+  - type: Sprite
+    layers:
+      - state: ring
+        color: "#535353"
+
+- type: loadout
+  id: RingThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 150h
+  storage:
+    back:
+    - BlackRing
+  groupBy: "ring"
+
+- type: loadout
+  id: HeadBandThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 10h
+  storage:
+    back:
+    - ClothingHeadBandBlack
+  groupBy: "hats"
+
+- type: loadout
+  id: CatHatThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 200h
+  storage:
+    back:
+    - ClothingHeadHatAnimalCat
+  groupBy: "hats"
+
+# endregion
+
+# region Neck
+
+- type: loadout
+  id: MaskThief
+  storage:
+    back:
+    - ClothingMaskBandBlack
+
+- type: entity
+  parent: ClothingNeckTieDet
+  id: ClothingNeckTieThief
+  name: black tie
+  description: This seems stolen...
+  suffix: Loadout, Trinkets, Thief
+
+- type: loadout
+  id: TieThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 20h
+  storage:
+    back:
+    - ClothingNeckTieThief
+
+- type: loadout
+  id: GaiterThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 40h
+  storage:
+    back:
+    - ClothingMaskNeckGaiter
+
+- type: loadout
+  id: PonchoSmallThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 80h
+  storage:
+    back:
+    - ClothingNeckPonchoSmallBlack
+
+- type: loadout
+  id: PonchoThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 120h
+  storage:
+    back:
+    - ClothingNeckPonchoBlack
+
+- type: loadout
+  id: ScarfThief
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 160h
+  storage:
+    back:
+    - ClothingNeckScarfStripedBlack
+
+# endregion

--- a/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/wizard.yml
+++ b/Resources/Prototypes/_Reserve/Loadouts/Miscellaneous/wizard.yml
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: roleLoadout
+  id: AntagWizard
+  groups:
+  - TrinketsWizard
+
+- type: loadoutGroup
+  id: TrinketsWizard
+  name: loadout-group-trinkets
+  minLimit: 0
+  maxLimit: 3
+  loadouts:
+  - DrinkMugWizard
+  - DrinkMugRainbowWizard
+  - DiceBagWizard
+  - d6DiceRainbow
+  - CrayonWizard
+  - SpellCardFun
+  - FoodSnackLollypopWizard
+  - FoodSnackLollypopMysteryWizard
+  - FoodSnackLollypopRainbowWizard
+  - TowelWizard
+  - RingWizard
+  - CannabisWizard
+  - DrugsWizard
+  - PlushieMagicarp
+  - SkullWizard
+  - LeftHandSkeletonNecromancer
+  - SkullRainbow
+  # - ???
+  # - ???
+  # - ???
+
+# region Drinks
+
+- type: loadout
+  id: DrinkMugWizard
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 35h
+  storage:
+    back:
+    - DrinkMugBlue
+  groupBy: "drinks"
+
+- type: loadout
+  id: DrinkMugRainbowWizard
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 70h
+  storage:
+    back:
+    - DrinkMugRainbow
+  groupBy: "drinks"
+
+# endregion
+
+# region Candy
+
+- type: entity
+  parent: FoodSnackLollypopDylovene
+  id: FoodSnackLollypopWizard
+  name: wizard lollypop
+  description: A lollypop filled with a special magic cocktail.
+  suffix: Loadout, Trinkets, Wizard
+  components:
+  - type: Sprite
+    layers:
+    - state: lollypop
+      map: [ "enum.AmmoVisualLayers.Base" ]
+    - state: color
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+      color: "#f333a3"
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Sugar
+          Quantity: 5
+        - ReagentId: BacchusBlessing
+          Quantity: 15
+
+- type: entity
+  parent: FoodSnackLollypopWizard
+  id: FoodSnackLollypopWizardDummy
+  categories: [ HideSpawnMenu ]
+  name: three wizard lollypops
+  components:
+  - type: Sprite
+    layers:
+    - state: lollypop
+      map: [ "enum.AmmoVisualLayers.Base" ]
+      offset: 0, -0.25
+    - state: color
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+      color: "#f333a3"
+      offset: 0, -0.25
+    - state: lollypop
+      offset: -0.1, 0.1
+    - state: color
+      color: "#f333a3"
+      offset: -0.1, 0.1
+    - state: lollypop
+      offset: 0.25, 0
+    - state: color
+      color: "#f333a3"
+      offset: 0.25, 0
+
+- type: loadout
+  id: FoodSnackLollypopWizard
+  dummyEntity: FoodSnackLollypopWizardDummy
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobBartender
+      time: 45h
+  storage:
+    back:
+    - FoodSnackLollypopWizard
+    - FoodSnackLollypopWizard
+    - FoodSnackLollypopWizard
+  groupBy: "candy"
+
+- type: entity
+  parent: FoodSnackLollypopWrappedMystery
+  id: FoodSnackLollypopWrappedMysteryDummy
+  categories: [ HideSpawnMenu ]
+  name: three mystery lollypops
+  components:
+  - type: Sprite
+    layers:
+    - state: lollypop-wrapped
+      offset: 0, -0.25
+    - state: lollypop-wrapped
+      offset: -0.1, 0.1
+    - state: lollypop-wrapped
+      offset: 0.25, 0
+
+- type: loadout
+  id: FoodSnackLollypopMysteryWizard
+  dummyEntity: FoodSnackLollypopWrappedMysteryDummy
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChef
+      time: 45h
+  storage:
+    back:
+    - FoodSnackLollypopWrappedMystery
+    - FoodSnackLollypopWrappedMysteryNeutral
+    - FoodSnackLollypopWrappedMysteryEvil
+  groupBy: "candy"
+
+- type: entity
+  parent: FoodSnackLollypopDylovene
+  id: FoodSnackLollypopRainbowWizard
+  name: rainbow lollypop
+  description: An enchanted lollypop. What could go wrong?
+  suffix: Loadout, Trinkets, Wizard
+  components:
+  - type: Sprite
+    layers:
+    - state: lollypop
+      map: [ "enum.AmmoVisualLayers.Base" ]
+    - state: color
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+  - type: PointLight
+    radius: 1.2
+    energy: 1.5
+  - type: RgbLightController
+    layers: [ 1 ]
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Sugar
+          Quantity: 5
+        - ReagentId: THC
+          Quantity: 15
+
+- type: entity
+  parent: FoodSnackLollypopRainbowWizard
+  id: FoodSnackLollypopRainbowWizardDummy
+  categories: [ HideSpawnMenu ]
+  name: three rainbow lollypops
+  components:
+  - type: Sprite
+    layers:
+    - state: lollypop
+      map: [ "enum.AmmoVisualLayers.Base" ]
+      offset: 0, -0.25
+    - state: color
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+      offset: 0, -0.25
+    - state: lollypop
+      offset: -0.1, 0.1
+    - state: color
+      offset: -0.1, 0.1
+    - state: lollypop
+      offset: 0.25, 0
+    - state: color
+      offset: 0.25, 0
+  - type: RgbLightController
+    layers: [ 1, 3, 5 ]
+
+- type: loadout
+  id: FoodSnackLollypopRainbowWizard
+  dummyEntity: FoodSnackLollypopRainbowWizardDummy
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobJanitor
+      time: 45h
+  storage:
+    back:
+    - FoodSnackLollypopRainbowWizard
+    - FoodSnackLollypopRainbowWizard
+    - FoodSnackLollypopRainbowWizard
+  groupBy: "candy"
+
+# endregion
+
+# region Toys
+
+- type: loadout
+  id: CrayonWizard
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobMime
+      time: 45h
+  storage:
+    back:
+    - CrayonRainbowLarge
+  groupBy: "cards"
+
+- type: loadout
+  id: PlushieMagicarp
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 120h
+  storage:
+    back:
+    - PlushieMagicarp
+  groupBy: "plushies"
+
+# endregion
+
+# region Dice
+
+- type: loadout
+  id: DiceBagWizard
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Cargo
+      time: 50h
+  storage:
+    back:
+    - MagicDiceBag
+  groupBy: "cards"
+
+# endregion
+
+# region Towel
+
+- type: entity
+  parent: BaseTowel
+  id: TowelColorWizard
+  name: wizard towel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#304094"
+    - state: iconstripe
+      color: "#943394"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#304094"
+      right:
+      - state: inhand-right
+        color: "#304094"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#304094"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#304094"
+      belt:
+      - state: equipped-BELT
+        color: "#304094"
+  - type: Fiber
+    fiberColor: fibers-blue
+
+- type: loadout
+  id: TowelWizard
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 30h
+  storage:
+    back:
+    - TowelColorWizard
+  groupBy: "towels"
+
+# endregion
+
+# region Other
+
+- type: entity
+  parent: PlasticRing
+  id: RingWizard
+  name: wizard ring
+  suffix: Loadout, Trinkets, Thief
+  components:
+  - type: Sprite
+    layers:
+      - state: ring
+        color: "#304094"
+      - state: gem
+        color: "#b35393"
+
+- type: loadout
+  id: RingWizard
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 150h
+  storage:
+    back:
+    - RingWizard
+  groupBy: "ring"
+
+- type: loadout
+  id: CannabisWizard
+  dummyEntity: LeavesCannabisRainbow
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobBotanist
+      time: 45h
+  storage:
+    back:
+    - LeavesCannabisRainbow
+    - LeavesCannabisRainbow
+    - LeavesCannabisRainbow
+
+- type: loadout
+  id: DrugsWizard
+  dummyEntity: PillSpaceDrugs
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobVirologist
+      time: 10h
+  storage:
+    back:
+    - PillSpaceDrugs
+    - PillSpaceDrugs
+    - PillSpaceDrugs
+    - PillSpaceDrugs
+
+# endregion
+
+# region Bones
+
+- type: loadout
+  id: SkullWizard
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChaplain
+      time: 10h
+  storage:
+    back:
+    - HeadSkeleton
+  groupBy: "skulls"
+
+- type: entity
+  parent: LeftHandSkeleton
+  id: LeftHandSkeletonNecromancer
+  name: necromancer's hand
+  description: A skeletal hand, used by necromancers for god knows what. It is said that the hand can be used to summon the dead. This one seems to have ran out of power?.. Does anybody have a charger?..
+  suffix: Loadout, Trinkets, Wizard
+
+- type: loadout
+  id: LeftHandSkeletonNecromancer
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChaplain
+      time: 20h
+  storage:
+    back:
+    - LeftHandSkeletonNecromancer
+  groupBy: "skulls"
+
+- type: entity
+  parent: HeadSkeleton
+  id: HeadSkeletonRainbow
+  name: rainbow skull
+  description: Why do wizards make everything rainbow?..
+  suffix: Loadout, Trinkets, Wizard, Ghost Role
+  components:
+  - type: PointLight
+    radius: 1.2
+    energy: 1.5
+  - type: RgbLightController
+    layers: [ 0 ]
+
+- type: loadout
+  id: SkullRainbow
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobClown
+      time: 20h
+  storage:
+    back:
+    - HeadSkeletonRainbow
+  groupBy: "skulls"
+
+# endregion


### PR DESCRIPTION
# Описание PR

Теперь у антагонистов тоже есть свои списки лодаутов! По крайней мере, у большинства.

- Исправлена система лодаутов для антагонистов (до этого она не выдавала предметы);
- Добавлено очень много вещей в лодауты антагонистов, из которых множество - новые, уникальные предметы, которые можно получить только через лодаут соответственного антагониста.

## Медиа

**WIP**...

## Изменения

:cl:
- add: Лодауты антагонистов и очень много вещей для них, из которых множество - новые, уникальные предметы, которые можно получить только через лодаут соответственного антагониста.
- fix: Система лодаутов для антагонистов (до этого она не выдавала предметы).
