### PR TITLE
Tiny post-upstream 2408 folder fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -55,12 +55,16 @@
     whitelist:
       tags:
       - Document
+      - Card  # Reserve: Folder fix
+      - CD  # Reserve: Folder fix
   - type: ItemMapper
     mapLayers:
       folder-overlay-paper:
         whitelist:
           tags:
           - Document
+          - Card  # Reserve: Folder fix
+          - CD  # Reserve: Folder fix
   - type: PhysicalComposition
     materialComposition:
       Paper: 50


### PR DESCRIPTION
# Описание PR

Папки снова вмещают карточки, а также теперь вмещают еще и CD-диски.

## Изменения

:cl:
- tweak: Кроме документов и карточек, папки теперь также вмещают еще и CD-диски.
